### PR TITLE
Add a Justfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,8 @@ jobs:
       - uses: astral-sh/setup-uv@v5
         with:
           python-version: "3.10"
+      - uses: extractions/setup-just@v3
       - name: install
         run: uv sync --all-extras
-      - name: check formatting
-        run: uv run ruff format --check
+      - name: lint
+        run: just lint

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,14 +1,29 @@
 # Contributing
 
-## Setup
+## Prerequisites
 
-Install [uv](https://docs.astral.sh/uv/getting-started/installation/), then run:
+* [uv](https://docs.astral.sh/uv/getting-started/installation/)
+* [Just](https://just.systems/man/en/)
+
+## Installation
 
 ```sh
 uv sync --all-extras
 ```
 
 (uv automatically creates and manages a virtual environment.)
+
+## Format code
+
+```
+just fmt
+```
+
+## Lint
+
+```
+just lint
+```
 
 ## Update dependencies
 
@@ -30,10 +45,4 @@ Add a dev dependency:
 
 ```
 uv add <dependency> --dev
-```
-
-## Format code
-
-```
-uv run ruff format
 ```

--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,5 @@
+fmt:
+    uv run ruff format
+
+lint:
+    uv run ruff format --check


### PR DESCRIPTION
Closes https://github.com/qiskit-community/Quantum-Challenge-Grader/issues/270.

I went with a Justfile rather than Makefile because Justfiles are much more modern and easy to set up than Makefiles. For example, you don't have to worry about spaces vs tabs, or `.PHONY`. Justfiles are extremely popular and well supported.

The only downside of Justfiles is the one-time installation, but they are easy to install, such as `brew install just`.