### PR TITLE
Add ty typechecker

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,11 @@ just fmt
 just lint
 ```
 
+To run the individual linters:
+
+* Ruff: `uv run ruff check`
+* Ty (type check): `uv run ty check`
+
 ## Tests
 
 ```

--- a/Justfile
+++ b/Justfile
@@ -4,6 +4,7 @@ fmt:
 lint:
     uv run ruff format --check
     uv run ruff check
+    uv run ty check --error-on-warning
 
 test:
     uv run pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ jupyter = [
 dev = [
     "pytest>=9.0.3",
     "ruff>=0.15.10",
+    "ty>=0.0.30",
 ]
 
 [tool.hatch.version]

--- a/qc_grader/challenges/qdc_2025/lattice.py
+++ b/qc_grader/challenges/qdc_2025/lattice.py
@@ -19,6 +19,7 @@ from typing import List, Tuple
 import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib as mpl
+import matplotlib.transforms
 
 
 # ---------------------------------------------------------------------------
@@ -49,7 +50,7 @@ def backends_objs_to_names(backends_arr):
         if isinstance(backend, str):
             backends_name_arr.append(backend)
         else:
-            backends_name_arr.append(backend.name)
+            backends_name_arr.append(backend.name)  # ty: ignore[unresolved-attribute]
 
     return backends_name_arr if len(backends_name_arr) > 1 else backends_name_arr[0]
 
@@ -428,7 +429,7 @@ class HeavyHexLattice:
             edges_boxes_x,
             edges_boxes_y,
             400 * scale,
-            marker=(4, 0, 45),
+            marker=(4, 0, 45),  # ty: ignore[invalid-argument-type]
             c="white",
             edgecolors="black",
             zorder=2,
@@ -590,8 +591,10 @@ class HeavyHexLattice:
                 try:
                     coords = np.array(coords)
                     return ~np.equal(coords.sum(axis=1) % 1, 0)
-                except np.AxisError:
-                    raise np.AxisError("Coords is not a valid tuple or N x 2 array")
+                except np.exceptions.AxisError:
+                    raise np.exceptions.AxisError(
+                        "Coords is not a valid tuple or N x 2 array"
+                    )
 
         plt.rc("font", family="serif")
 
@@ -694,7 +697,7 @@ class HeavyHexLattice:
             edges_boxes_x[highlighted_edges_inds],
             edges_boxes_y[highlighted_edges_inds],
             400 * scale,
-            marker=(4, 0, 45),
+            marker=(4, 0, 45),  # ty: ignore[invalid-argument-type]
             c=colors[highlighted_edges_color_inds],
             edgecolors="black",
             zorder=2,
@@ -703,7 +706,7 @@ class HeavyHexLattice:
             edges_boxes_x[non_highlighted_edges_inds],
             edges_boxes_y[non_highlighted_edges_inds],
             400 * scale,
-            marker=(4, 0, 45),
+            marker=(4, 0, 45),  # ty: ignore[invalid-argument-type]
             c="white",
             edgecolors="black",
             zorder=2,

--- a/qc_grader/challenges/qdc_2025/qdc25_lab5.py
+++ b/qc_grader/challenges/qdc_2025/qdc25_lab5.py
@@ -60,7 +60,7 @@ def grade_lab5_ex3(qc: QuantumCircuit) -> None:
 @typechecked
 def grade_lab_5_ex4(
     user_hv: float,
-    samples: np.array,
+    samples: np.array,  # ty: ignore[invalid-type-form]
     isa_qc: QuantumCircuit,
     params: dict,
     job_ids: list,

--- a/qc_grader/challenges/qdc_2025/qdc25_lab7.py
+++ b/qc_grader/challenges/qdc_2025/qdc25_lab7.py
@@ -98,7 +98,7 @@ def grade_lab7_ex3(qubo: OptimizationProblem, A: np.ndarray, b: np.ndarray) -> N
     - qubo: OptimizationProblem instance with proper objective function
     """
 
-    linear_dict = {idx: val for idx, val in enumerate(qubo.objective.linear)}
+    linear_dict = {idx: val for idx, val in enumerate(qubo.objective.linear)}  # ty: ignore[invalid-argument-type]
     # convert tuple key to string for serialization, e.g. (0, 0) => '(0, 0)'
     quadratic_dict = {str(k): v for k, v in qubo.objective.quadratic.to_dict().items()}
 
@@ -124,7 +124,7 @@ def grade_lab7_ex4(problem: Dict, qubo: OptimizationProblem) -> None:
     - qubo: OptimizationProblem instance for validation
     """
 
-    linear_dict = {idx: val for idx, val in enumerate(qubo.objective.linear)}
+    linear_dict = {idx: val for idx, val in enumerate(qubo.objective.linear)}  # ty: ignore[invalid-argument-type]
     # convert tuple key to string for serialization, e.g. (0, 0) => '(0, 0)'
     quadratic_dict = {str(k): v for k, v in qubo.objective.quadratic.to_dict().items()}
 

--- a/qc_grader/challenges/qdc_2025/qdc25_lab8.py
+++ b/qc_grader/challenges/qdc_2025/qdc25_lab8.py
@@ -49,7 +49,7 @@ def grade_lab8_ex1(parse_func: Callable) -> None:
 
 @typechecked
 def grade_lab8_ex2(qubo: OptimizationProblem) -> None:
-    linear_dict = {idx: val for idx, val in enumerate(qubo.objective.linear)}
+    linear_dict = {idx: val for idx, val in enumerate(qubo.objective.linear)}  # ty: ignore[invalid-argument-type]
     # convert tuple key to string for serialization, e.g. (0, 0) => '(0, 0)'
     quadratic_dict = {str(k): v for k, v in qubo.objective.quadratic.to_dict().items()}
 

--- a/qc_grader/custom_encoder/json_encoder.py
+++ b/qc_grader/custom_encoder/json_encoder.py
@@ -35,51 +35,51 @@ def to_json(obj: Any, **kwargs) -> str:
 
 
 class GraderJSONEncoder(json.JSONEncoder):
-    def default(self, obj: Any) -> Any:
-        match type(obj).__name__:
+    def default(self, o: Any) -> Any:
+        match type(o).__name__:
             case numpy.integer.__name__:
-                return serializer.dump_numpy_integer(obj)
+                return serializer.dump_numpy_integer(o)
             case numpy.floating.__name__:
-                return serializer.dump_numpy_floating(obj)
+                return serializer.dump_numpy_floating(o)
             case numpy.bool_.__name__:
-                return serializer.dump_numpy_bool(obj)
+                return serializer.dump_numpy_bool(o)
             case numpy.ndarray.__name__:
-                return serializer.dump_numpy_ndarray(obj)
+                return serializer.dump_numpy_ndarray(o)
             case numpy.complex128.__name__:
-                return serializer.dump_numpy_complex(obj)
+                return serializer.dump_numpy_complex(o)
             case complex.__name__:
-                return serializer.dump_complex(obj)
+                return serializer.dump_complex(o)
             case Fraction.__name__:
-                return serializer.dump_fraction(obj)
+                return serializer.dump_fraction(o)
             case Parameter.__name__:
-                return serializer.dump_parameter(obj)
+                return serializer.dump_parameter(o)
             case TwoLocal.__name__:
-                return serializer.dump_two_local(obj)
+                return serializer.dump_two_local(o)
             case QuantumCircuit.__name__:
-                return serializer.dump_quantum_circuit(obj)
+                return serializer.dump_quantum_circuit(o)
             case SamplerResult.__name__:
-                return serializer.dump_sampler_result(obj)
+                return serializer.dump_sampler_result(o)
             case EstimatorResult.__name__:
-                return serializer.dump_estimator_result(obj)
+                return serializer.dump_estimator_result(o)
             case PrimitiveResult.__name__:
-                return serializer.dump_primitive_result(obj)
+                return serializer.dump_primitive_result(o)
             case QuasiDistribution.__name__:
-                return serializer.dump_quasi_distribution(obj)
+                return serializer.dump_quasi_distribution(o)
             case ProbDistribution.__name__:
-                return serializer.dump_prob_distribution(obj)
+                return serializer.dump_prob_distribution(o)
             case Statevector.__name__:
-                return serializer.dump_state_vector(obj)
+                return serializer.dump_state_vector(o)
             case Operator.__name__:
-                return serializer.dump_operator(obj)
+                return serializer.dump_operator(o)
             case SparsePauliOp.__name__:
-                return serializer.dump_sparse_pauli_op(obj)
+                return serializer.dump_sparse_pauli_op(o)
             case NoiseModel.__name__:
-                return serializer.dump_noise_model(obj)
+                return serializer.dump_noise_model(o)
             case Pauli.__name__:
-                return serializer.dump_pauli(obj)
+                return serializer.dump_pauli(o)
             case Graph.__name__:
-                return serializer.dump_graph(obj)
+                return serializer.dump_graph(o)
             case "dict_keys":
-                return serializer.dump_dict_keys(obj)
+                return serializer.dump_dict_keys(o)
             case _:
-                return json.JSONEncoder.default(self, obj)
+                return json.JSONEncoder.default(self, o)

--- a/qc_grader/custom_encoder/json_encoder_test.py
+++ b/qc_grader/custom_encoder/json_encoder_test.py
@@ -1,3 +1,13 @@
+# (C) Copyright IBM 2026
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
 import json
 
 import numpy as np

--- a/qc_grader/custom_encoder/serializer.py
+++ b/qc_grader/custom_encoder/serializer.py
@@ -30,7 +30,7 @@ from qiskit_aer.noise import NoiseModel
 from networkx.classes import Graph
 
 
-def circuit_to_bytes(qc: Union[TwoLocal, QuantumCircuit]) -> dict:
+def circuit_to_bytes(qc: Union[TwoLocal, QuantumCircuit]) -> bytes:
     with BytesIO() as container:
         qpy.dump(qc, container)
         circuit = container.getvalue()

--- a/qc_grader/grader/auth.py
+++ b/qc_grader/grader/auth.py
@@ -80,6 +80,6 @@ https://quantum.cloud.ibm.com/docs/en/guides/save-credentials
             iam_api_key=self.api_key
         ).get_result()
         return {
-            "account_id": details.get("account_id"),
-            "iam_id": details.get("iam_id"),
+            "account_id": details.get("account_id"),  # ty: ignore[unresolved-attribute]
+            "iam_id": details.get("iam_id"),  # ty: ignore[unresolved-attribute]
         }

--- a/qc_grader/grader/grade.py
+++ b/qc_grader/grader/grade.py
@@ -31,17 +31,17 @@ def grade(
     challenge: Optional[str] = None,
     return_response: Optional[bool] = False,
     **kwargs: Any,
-) -> Tuple[bool, Optional[Union[str, int, float]], Optional[Union[str, int, float]]]:
+) -> Tuple[bool, Optional[Union[str, int, float]], Optional[Union[str, int, float]]]:  # ty: ignore[invalid-return-type]
     serialized_answer = to_json(answer, **kwargs)
 
     if challenge is None and "/" in str(question):
-        challenge_id = question.split("/")[0]
-        question_id = question.split("/")[1]
+        challenge_id = question.split("/")[0]  # ty: ignore[unresolved-attribute]
+        question_id = question.split("/")[1]  # ty: ignore[unresolved-attribute]
     else:
         question_id = question
         challenge_id = challenge
 
-    endpoint = get_grading_endpoint(question_id, challenge_id)
+    endpoint = get_grading_endpoint(question_id, challenge_id)  # ty: ignore[invalid-argument-type]
     payload = {"answer": serialized_answer}
 
     if serialized_answer is not None and endpoint:
@@ -65,7 +65,7 @@ def grade_answer(
     endpoint: str,
     max_content_length: Optional[int] = None,
     return_response: Optional[bool] = False,
-) -> Tuple[bool, Optional[Union[str, int, float]], Optional[Union[str, int, float]]]:
+) -> Tuple[bool, Optional[Union[str, int, float]], Optional[Union[str, int, float]]]:  # ty: ignore[invalid-return-type]
     try:
         access_token = iam_auth.get_access_token()
         account = iam_auth.get_user_account()
@@ -90,7 +90,7 @@ def grade_answer(
             s = status == "valid" or status is True
             return s, score, cause
 
-        handle_grade_response(status, score=score, cause=cause)
+        handle_grade_response(status, score=score, cause=cause)  # ty: ignore[invalid-argument-type]
 
     except Exception as err:
         print(f"Failed: {err}")

--- a/uv.lock
+++ b/uv.lock
@@ -3849,6 +3849,7 @@ qiskit = [
 dev = [
     { name = "pytest" },
     { name = "ruff" },
+    { name = "ty" },
 ]
 
 [package.metadata]
@@ -3872,6 +3873,7 @@ provides-extras = ["jupyter", "qiskit"]
 dev = [
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "ruff", specifier = ">=0.15.10" },
+    { name = "ty", specifier = ">=0.0.30" },
 ]
 
 [[package]]
@@ -4790,6 +4792,30 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/eb/79/72064e6a701c2183016abbbfedaba506d81e30e232a68c9f0d6f6fcd1574/traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7", size = 161621, upload-time = "2024-04-19T11:11:49.746Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f", size = 85359, upload-time = "2024-04-19T11:11:46.763Z" },
+]
+
+[[package]]
+name = "ty"
+version = "0.0.30"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/62/21/3ee32f163038ac2663c7bea47a07d06bf4cc7c09d95b96db194bda1b70cb/ty-0.0.30.tar.gz", hash = "sha256:c982207640e7d75331b81031ebfb884ab858ed26ab16d7c086ac4942e2771846", size = 5518350, upload-time = "2026-04-14T13:53:35.462Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/24/7aa94d02a9257ed96e64e4e99b527f28390febd8424107b4f8a70763ace9/ty-0.0.30-py3-none-linux_armv6l.whl", hash = "sha256:1be31a24a2a177571c3276854bf01b2b1a77dba6e754507089c25bb1825ce5f6", size = 10801835, upload-time = "2026-04-14T13:53:21.477Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/97/2410ebc85cfcdf3bbd0e5958c6cd0b88085b1a184374ecfa755f84d6c8b2/ty-0.0.30-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:019f1d0d5d5265a1e634a51fd49374df43dafae14de98c2a0d349beb8233550b", size = 10582386, upload-time = "2026-04-14T13:53:07.472Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/d2/a2649eb6841ebf946ac827e778b7e78b5ef63c3758bf2b9da13d927a53da/ty-0.0.30-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fe3012af4d0714e7353fd3cf6d2d02d5b0f0fe6f1cb8beb2366ed9f621c2c349", size = 10031621, upload-time = "2026-04-14T13:53:01.523Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/8e/40a66ccd5d5d51adf0469b9fbe4f1f79f928a880b34b8a6c7c934e8a883a/ty-0.0.30-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d1e90b4ebf6310c7734344739e0950f4cede5a33b1e51a12a0c0fc8a975866ed", size = 10537511, upload-time = "2026-04-14T13:53:04.538Z" },
+    { url = "https://files.pythonhosted.org/packages/25/31/5dea2987601ef1c8c58b04f2173971e7fe51f7902ab93a66d09e0f12115a/ty-0.0.30-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fd83a0d82cbc32c2ae521e7fa101fb5fe5b566adb1364996582535700572a9ec", size = 10603406, upload-time = "2026-04-14T13:53:47.564Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/a4/5a7585b6b219a2edc00255af0b16a8475f88fe43c5cdbe499daecb67f100/ty-0.0.30-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:672a29271c13247096d0b2766e69cb35b1583882dd6e7b24065927e2491ffe6d", size = 11109133, upload-time = "2026-04-14T13:53:24.463Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/83/b402dc4bd99b6f3eb0bce04e557889a164e099976a7fc71a6b07c923241b/ty-0.0.30-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:91ff236adbb90281c05f7e160664820be50f42d3a9d8f1d0a648f006864114fa", size = 11663362, upload-time = "2026-04-14T13:53:18.505Z" },
+    { url = "https://files.pythonhosted.org/packages/65/1b/8157f03acc15421083c194b11a61a78d10e3dfa7e4a0177809fc9acc3881/ty-0.0.30-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6ec99bd5d5430c52fb64038483deb070f12c7ae78ffd6d6841d31719daedf1d7", size = 11304786, upload-time = "2026-04-14T13:53:30.076Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/c3/f89a9a42b47da108ed758ae9d065d10bf2acc2ea88e3d200b95511096b7b/ty-0.0.30-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a4b328ee332ec6276afc863ea7cf6d8167d9dd8d9f3d1c2e738ef39932511ac4", size = 11173426, upload-time = "2026-04-14T13:53:10.262Z" },
+    { url = "https://files.pythonhosted.org/packages/81/37/fa38ee0259dc49579e1871b23ab1ff27331a78460566cdc13045a237595d/ty-0.0.30-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:fd0d664d6530890a8e872accd96895410773e7a4c6d20c244fb7a5f541ff359b", size = 10517157, upload-time = "2026-04-14T13:53:15.739Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/79/28032481141eb6ce3274f62b9ff9b1d73d59df6b28080c8fe3c6bdef700e/ty-0.0.30-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:314004166a7a5e39e169c7da0b9e78f3315382f53db8698fd98346cee3bb0784", size = 10613222, upload-time = "2026-04-14T13:53:13.269Z" },
+    { url = "https://files.pythonhosted.org/packages/45/a0/989fca4c74095defd7d3ba5afc68a5aa4e2ca428fedfca5df526701c730b/ty-0.0.30-py3-none-musllinux_1_2_i686.whl", hash = "sha256:d969ebf9d8b08e93e638c56e6fb5a8dacd2a24f43e3519479d245ddde69f968e", size = 10789624, upload-time = "2026-04-14T13:53:42.156Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/74/3e74aba392ba2eeae5d86568ee282d9d6b2b6642445e3d9837c88d73c282/ty-0.0.30-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:66922c8c4381a016f90ec4b811748e7bb12da892f4c273640710da721caea7fb", size = 11260273, upload-time = "2026-04-14T13:53:44.974Z" },
+    { url = "https://files.pythonhosted.org/packages/24/0e/e94a0e5e5a1850a2ba61c5efcfa594cfc2d23c026bf431cce33003d036a0/ty-0.0.30-py3-none-win32.whl", hash = "sha256:b7b2ecf80c872d7d9928b372e99233bdda7cabe639edd06b6232c3161a7dfa40", size = 10145096, upload-time = "2026-04-14T13:53:39.335Z" },
+    { url = "https://files.pythonhosted.org/packages/50/d3/09c8df72ad37f7f4d9d79fe04a08bfa649d9f141d137e624fc23c7c3d7fe/ty-0.0.30-py3-none-win_amd64.whl", hash = "sha256:f29834e3d96c447f2adcf9eeb55b3f92005c91f52597c4c46d844188ec67ec72", size = 11156009, upload-time = "2026-04-14T13:53:32.847Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/17/a5c049c36e2fef9c593a1862f275af963b66045378f10b6908c6f10f6f4a/ty-0.0.30-py3-none-win_arm64.whl", hash = "sha256:d9be1d258dab615b447d20fa58633f0ae163af01bfa781a50457defec20642fd", size = 10552887, upload-time = "2026-04-14T13:53:27.455Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes https://github.com/qiskit-community/Quantum-Challenge-Grader/issues/256. 

This only fixes type issues I was confident on. https://github.com/qiskit-community/Quantum-Challenge-Grader/issues/281 tracks fixing remaining issues. I don't plan to fix the qdc_2025 issues because I don't want to modify that code.

## Why ty

I chose ty over MyPy because it is 10-100x faster. It also has excellent diagnostics inspired by rustc. It's backed by Astral, the company behind uv and Ruff, so it should be low maintenance debt. If it ever becomes unsupported, we can of course switch to MyPy.