### PR TITLE
Add missing copyright and remove misleading file headers

### DIFF
--- a/qc_grader/challenges/__init__.py
+++ b/qc_grader/challenges/__init__.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-
 # (C) Copyright IBM 2024
 #
 # This code is licensed under the Apache License, Version 2.0. You may

--- a/qc_grader/challenges/qdc_2025/__init__.py
+++ b/qc_grader/challenges/qdc_2025/__init__.py
@@ -1,3 +1,13 @@
+# (C) Copyright IBM 2025
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
 from .qdc25_lab1 import (
     submit_name,
     grade_lab1_ex1,

--- a/qc_grader/challenges/qdc_2025/lattice.py
+++ b/qc_grader/challenges/qdc_2025/lattice.py
@@ -1,3 +1,13 @@
+# (C) Copyright IBM 2025
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
 """
 Library for constructing and visualizing LGTs in an
 IBM's Heavy-Hex lattice.

--- a/qc_grader/challenges/qdc_2025/qdc25_lab1.py
+++ b/qc_grader/challenges/qdc_2025/qdc25_lab1.py
@@ -1,3 +1,13 @@
+# (C) Copyright IBM 2025
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
 from typeguard import typechecked
 
 from qiskit import QuantumCircuit

--- a/qc_grader/challenges/qdc_2025/qdc25_lab2.py
+++ b/qc_grader/challenges/qdc_2025/qdc25_lab2.py
@@ -1,3 +1,13 @@
+# (C) Copyright IBM 2025
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
 from typeguard import typechecked
 
 from qiskit import QuantumCircuit

--- a/qc_grader/challenges/qdc_2025/qdc25_lab3.py
+++ b/qc_grader/challenges/qdc_2025/qdc25_lab3.py
@@ -1,3 +1,13 @@
+# (C) Copyright IBM 2025
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
 from typeguard import typechecked
 
 from qiskit import QuantumCircuit

--- a/qc_grader/challenges/qdc_2025/qdc25_lab4.py
+++ b/qc_grader/challenges/qdc_2025/qdc25_lab4.py
@@ -1,3 +1,13 @@
+# (C) Copyright IBM 2025
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
 from typeguard import typechecked
 
 from qc_grader.grader.grade import grade

--- a/qc_grader/challenges/qdc_2025/qdc25_lab5.py
+++ b/qc_grader/challenges/qdc_2025/qdc25_lab5.py
@@ -1,3 +1,13 @@
+# (C) Copyright IBM 2025
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
 from typeguard import typechecked
 
 from qiskit import QuantumCircuit

--- a/qc_grader/challenges/qdc_2025/qdc25_lab6.py
+++ b/qc_grader/challenges/qdc_2025/qdc25_lab6.py
@@ -1,3 +1,13 @@
+# (C) Copyright IBM 2025
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
 from typeguard import typechecked, check_type
 
 from qc_grader.grader.grade import grade

--- a/qc_grader/challenges/qdc_2025/qdc25_lab7.py
+++ b/qc_grader/challenges/qdc_2025/qdc25_lab7.py
@@ -1,3 +1,13 @@
+# (C) Copyright IBM 2025
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
 from typeguard import typechecked
 from typing import Callable, Optional, Dict
 import tempfile

--- a/qc_grader/challenges/qdc_2025/qdc25_lab8.py
+++ b/qc_grader/challenges/qdc_2025/qdc25_lab8.py
@@ -1,3 +1,13 @@
+# (C) Copyright IBM 2025
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
 from typeguard import typechecked
 from typing import Callable
 import os

--- a/qc_grader/challenges/qdc_2025/qmoo_files.py
+++ b/qc_grader/challenges/qdc_2025/qmoo_files.py
@@ -1,3 +1,13 @@
+# (C) Copyright IBM 2025
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
 import glob
 import json
 import networkx as nx

--- a/qc_grader/challenges/test_challenge/__init__.py
+++ b/qc_grader/challenges/test_challenge/__init__.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-
 # (C) Copyright IBM 2024
 #
 # This code is licensed under the Apache License, Version 2.0. You may

--- a/qc_grader/challenges/test_challenge/exercise1.py
+++ b/qc_grader/challenges/test_challenge/exercise1.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-
 # (C) Copyright IBM 2024
 #
 # This code is licensed under the Apache License, Version 2.0. You may

--- a/qc_grader/challenges/test_challenge/exercise2.py
+++ b/qc_grader/challenges/test_challenge/exercise2.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-
 # (C) Copyright IBM 2024
 #
 # This code is licensed under the Apache License, Version 2.0. You may

--- a/qc_grader/custom_encoder/__init__.py
+++ b/qc_grader/custom_encoder/__init__.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-
 # (C) Copyright IBM 2024
 #
 # This code is licensed under the Apache License, Version 2.0. You may

--- a/qc_grader/custom_encoder/json_encoder.py
+++ b/qc_grader/custom_encoder/json_encoder.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-
 # (C) Copyright IBM 2024
 #
 # This code is licensed under the Apache License, Version 2.0. You may

--- a/qc_grader/custom_encoder/json_encoder_test.py
+++ b/qc_grader/custom_encoder/json_encoder_test.py
@@ -1,3 +1,13 @@
+# (C) Copyright IBM 2026
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
 import json
 
 import numpy as np

--- a/qc_grader/custom_encoder/serializer.py
+++ b/qc_grader/custom_encoder/serializer.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-
 # (C) Copyright IBM 2024
 #
 # This code is licensed under the Apache License, Version 2.0. You may

--- a/qc_grader/grader/__init__.py
+++ b/qc_grader/grader/__init__.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-
 # (C) Copyright IBM 2024
 #
 # This code is licensed under the Apache License, Version 2.0. You may

--- a/qc_grader/grader/api.py
+++ b/qc_grader/grader/api.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-
 # (C) Copyright IBM 2024
 #
 # This code is licensed under the Apache License, Version 2.0. You may

--- a/qc_grader/grader/auth.py
+++ b/qc_grader/grader/auth.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-
 # (C) Copyright IBM 2025
 #
 # This code is licensed under the Apache License, Version 2.0. You may

--- a/qc_grader/grader/common.py
+++ b/qc_grader/grader/common.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-
 # (C) Copyright IBM 2024
 #
 # This code is licensed under the Apache License, Version 2.0. You may

--- a/qc_grader/grader/grade.py
+++ b/qc_grader/grader/grade.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-
 # (C) Copyright IBM 2024
 #
 # This code is licensed under the Apache License, Version 2.0. You may


### PR DESCRIPTION
Some files had the shebang `#!/usr/bin/env python3`, which is misleading because they weren't actually executable files. They also had ` -*- coding: utf-8 -*-` to say the file is UTF-8, which has been unnecessary for years.