### PR TITLE
Restore submit_name to QDC 2025

### DIFF
--- a/qc_grader/challenges/qdc_2025/qdc25_lab2.py
+++ b/qc_grader/challenges/qdc_2025/qdc25_lab2.py
@@ -28,6 +28,17 @@ _challenge_id = "qdc_2025"
 
 
 @typechecked
+def submit_name(name: str) -> None:
+    status, score, message = grade(
+        name, "submit-name", _challenge_id, return_response=True
+    )
+    if status is False:
+        print(message)
+    else:
+        print("Team name submitted.")
+
+
+@typechecked
 def grade_lab2_ex1(observables: List) -> None:
     grade(observables, "lab2-ex1", _challenge_id)
 

--- a/qc_grader/challenges/qdc_2025/qdc25_lab3.py
+++ b/qc_grader/challenges/qdc_2025/qdc25_lab3.py
@@ -18,6 +18,17 @@ _challenge_id = "qdc_2025"
 
 
 @typechecked
+def submit_name(name: str) -> None:
+    status, score, message = grade(
+        name, "submit-name", _challenge_id, return_response=True
+    )
+    if status is False:
+        print(message)
+    else:
+        print("Team name submitted.")
+
+
+@typechecked
 def grade_lab3_ex1(
     mps_energies_t0: numpy.ndarray, mps_wp_circ_t0: QuantumCircuit
 ) -> None:

--- a/qc_grader/challenges/qdc_2025/qdc25_lab4.py
+++ b/qc_grader/challenges/qdc_2025/qdc25_lab4.py
@@ -39,6 +39,17 @@ IMPURITY_INDEX = (NBATH) // 2
 
 
 @typechecked
+def submit_name(name: str) -> None:
+    status, score, message = grade(
+        name, "submit-name", _challenge_id, return_response=True
+    )
+    if status is False:
+        print(message)
+    else:
+        print("Team name submitted.")
+
+
+@typechecked
 def grade_lab4_ex1(perturbed_tfim_hamiltonian: Callable) -> None:
     H_test = perturbed_tfim_hamiltonian(NUM_QUBITS, J, H_X, H_Z)
 

--- a/qc_grader/challenges/qdc_2025/qdc25_lab5.py
+++ b/qc_grader/challenges/qdc_2025/qdc25_lab5.py
@@ -26,6 +26,17 @@ _challenge_id = "qdc_2025"
 
 
 @typechecked
+def submit_name(name: str) -> None:
+    status, score, message = grade(
+        name, "submit-name", _challenge_id, return_response=True
+    )
+    if status is False:
+        print(message)
+    else:
+        print("Team name submitted.")
+
+
+@typechecked
 def grade_lab5_ex1(gen_cvecs: Callable) -> None:
     samples = []
     for _ in range(3):

--- a/qc_grader/challenges/qdc_2025/qdc25_lab6.py
+++ b/qc_grader/challenges/qdc_2025/qdc25_lab6.py
@@ -16,6 +16,17 @@ _challenge_id = "qdc_2025"
 
 
 @typechecked
+def submit_name(name: str) -> None:
+    status, score, message = grade(
+        name, "submit-name", _challenge_id, return_response=True
+    )
+    if status is False:
+        print(message)
+    else:
+        print("Team name submitted.")
+
+
+@typechecked
 def grade_lab6_ex1(molecule_name: str, hartree_fock_E: float) -> None:
 
     answer_dict = {

--- a/qc_grader/challenges/qdc_2025/qdc25_lab7.py
+++ b/qc_grader/challenges/qdc_2025/qdc25_lab7.py
@@ -22,6 +22,17 @@ from qc_grader.grader.grade import grade
 _challenge_id = "qdc_2025"
 
 
+@typechecked
+def submit_name(name: str) -> None:
+    status, score, message = grade(
+        name, "submit-name", _challenge_id, return_response=True
+    )
+    if status is False:
+        print(message)
+    else:
+        print("Team name submitted.")
+
+
 def validate_function(
     function_provider: str,
     function_title: str,

--- a/qc_grader/challenges/qdc_2025/qdc25_lab8.py
+++ b/qc_grader/challenges/qdc_2025/qdc25_lab8.py
@@ -44,6 +44,17 @@ grade_qctrl_function = make_validator("q-ctrl")
 
 
 @typechecked
+def submit_name(name: str) -> None:
+    status, score, message = grade(
+        name, "submit-name", _challenge_id, return_response=True
+    )
+    if status is False:
+        print(message)
+    else:
+        print("Team name submitted.")
+
+
+@typechecked
 def grade_lab8_ex1(parse_func: Callable) -> None:
 
     base_dir = os.path.dirname(__file__)


### PR DESCRIPTION
We got a user report this morning that this import failed:

```
AttributeError: module 'qc_grader.challenges.qdc_2025.qdc25_lab6' has no attribute 'submit_name'"
```

https://github.com/qiskit-community/Quantum-Challenge-Grader/pull/279 broke them because we removed the duplication functions, with the idea that people would import `qc_grader.challenges.qdc_2025`. Turns out, that was wrong. We add back that code.