### PR TITLE
Remove unused mechanisms from grade() API

### DIFF
--- a/qc_grader/custom_encoder/json_encoder.py
+++ b/qc_grader/custom_encoder/json_encoder.py
@@ -27,8 +27,8 @@ from qiskit_aer.noise import NoiseModel
 from . import serializer
 
 
-def to_json(obj: Any, **kwargs) -> str:
-    return json.dumps(obj, skipkeys=True, cls=GraderJSONEncoder, **kwargs)
+def to_json(obj: Any) -> str:
+    return json.dumps(obj, skipkeys=True, cls=GraderJSONEncoder)
 
 
 class GraderJSONEncoder(json.JSONEncoder):

--- a/qc_grader/grader/api.py
+++ b/qc_grader/grader/api.py
@@ -20,47 +20,12 @@ GRADER_URL = os.environ.get("QC_GRADER_URL", "https://qac-grading.quantum.ibm.co
 IAM_URL = os.environ.get("QC_IAM_URL", default="https://iam.cloud.ibm.com")
 
 
-class MaxContentError(BaseException):
-    def __init__(self, content_length: int, max_content_length: int) -> None:
-        self.message = (
-            f"Max content length ({max_content_length}) exceeded: {content_length}"
-        )
-
-    def __str__(self) -> str:
-        return self.message
-
-
-def compute_content_length(
-    endpoint: str,
-    query: Optional[Dict[str, str]] = None,
-    body: Optional[Dict[str, str]] = None,
-    method: str = "POST",
-    header: Optional[Mapping[str, str]] = None,
-) -> int:
-    from requests import Request
-
-    header = (
-        header
-        if header
-        else {
-            "Accept": "application/json",
-            "Content-Type": "application/json",
-            "X-Client-Version": __version__,
-        }
-    )
-
-    req = Request(method, url=endpoint, params=query, json=body, headers=header)
-    prepped = req.prepare()
-    return int(prepped.headers["Content-Length"])
-
-
 def send_request(
     endpoint: str,
     query: Optional[Dict[str, str]] = None,
     body: Optional[Dict[str, str]] = None,
     method: str = "POST",
     header: Optional[Mapping[str, str]] = None,
-    max_content_length: Optional[int] = None,
 ) -> Dict[str, str]:
     default_header = {
         "Accept": "application/json",
@@ -69,11 +34,6 @@ def send_request(
     }
     additional_header = header or {}
     header = {**default_header, **additional_header}
-
-    if max_content_length:
-        content_length = compute_content_length(endpoint, body=body)
-        if content_length >= max_content_length:
-            raise MaxContentError(content_length, max_content_length)
 
     response = requests.request(
         method, url=endpoint, params=query, json=body, headers=header

--- a/qc_grader/grader/grade.py
+++ b/qc_grader/grader/grade.py
@@ -21,43 +21,27 @@ iam_auth = IAMAuth()
 
 def grade(
     answer: Any,
-    question: Union[str, int],
-    challenge: Optional[str] = None,
+    question: str,
+    challenge: str,
     return_response: Optional[bool] = False,
-    **kwargs: Any,
 ) -> Tuple[bool, Optional[Union[str, int, float]], Optional[Union[str, int, float]]]:  # ty: ignore[invalid-return-type]
-    serialized_answer = to_json(answer, **kwargs)
+    endpoint = f"{GRADER_URL}/challenges/{challenge}/validate/{question}"
+    payload = {"answer": to_json(answer)}
 
-    if challenge is None and "/" in str(question):
-        challenge_id = question.split("/")[0]  # ty: ignore[unresolved-attribute]
-        question_id = question.split("/")[1]  # ty: ignore[unresolved-attribute]
-    else:
-        question_id = question
-        challenge_id = challenge
+    print("Grading your answer. Please wait...")
+    result = grade_answer(
+        payload,
+        endpoint,
+        return_response=return_response,
+    )
 
-    endpoint = f"{GRADER_URL}/challenges/{challenge_id}/validate/{question_id}"
-    payload = {"answer": serialized_answer}
-
-    if serialized_answer is not None and endpoint:
-        print("Grading your answer. Please wait...")
-
-        result = grade_answer(
-            payload,
-            endpoint,
-            max_content_length=kwargs.get("max_content_length", None),
-            return_response=return_response,
-        )
-
-        if return_response:
-            return result
-    else:
-        handle_grade_response("failed")
+    if return_response:
+        return result
 
 
 def grade_answer(
     payload: Dict[str, str],
     endpoint: str,
-    max_content_length: Optional[int] = None,
     return_response: Optional[bool] = False,
 ) -> Tuple[bool, Optional[Union[str, int, float]], Optional[Union[str, int, float]]]:  # ty: ignore[invalid-return-type]
     try:
@@ -72,9 +56,7 @@ def grade_answer(
         else:
             header = None
 
-        answer_response = send_request(
-            endpoint, body=payload, header=header, max_content_length=max_content_length
-        )
+        answer_response = send_request(endpoint, body=payload, header=header)
 
         status = answer_response.get("status", None)
         cause = answer_response.get("cause", None)


### PR DESCRIPTION
Towards https://github.com/qiskit-community/Quantum-Challenge-Grader/issues/287.

This change uses our typechecker `ty` to show that the changes are safe, such as why it's safe that we now require the `challenge` arg to be set.

For now, we remove the unused max content length mechanism. It might be dded back in https://github.com/qiskit-community/Quantum-Challenge-Grader/issues/290, but in a different way.