### PR TITLE
Run auth check at runtime, not import time

### DIFF
--- a/qc_grader/grader/grade.py
+++ b/qc_grader/grader/grade.py
@@ -16,8 +16,6 @@ from qc_grader.grader.auth import IAMAuth
 
 from .api import GRADER_URL, send_request
 
-iam_auth = IAMAuth()
-
 
 def grade(
     answer: Any,
@@ -45,6 +43,7 @@ def grade_answer(
     return_response: Optional[bool] = False,
 ) -> Tuple[bool, Optional[Union[str, int, float]], Optional[Union[str, int, float]]]:  # ty: ignore[invalid-return-type]
     try:
+        iam_auth = IAMAuth()
         access_token = iam_auth.get_access_token()
         account = iam_auth.get_user_account()
         if access_token:


### PR DESCRIPTION
Closes https://github.com/qiskit-community/Quantum-Challenge-Grader/issues/283, and partially addresses https://github.com/qiskit-community/Quantum-Challenge-Grader/issues/295.

Motivations for this change:

1. Improve the user experience of the error message. Before, importing without credentials set up would result in a scary stack trace. Imo, it's better to not error at import time and only error when you try running the exercises. This way, we also don't have the stack trace thanks to the try statement.

```
>>> grade_ex1a("")
Grading your answer. Please wait...
Failed: Your IBM Quantum Platform API key is missing or not properly saved.

Save your account by following the instructions at https://quantum.cloud.ibm.com/docs/en/guides/hello-world#install-and-authenticate to use `QiskitRuntimeService.save_account()`.

Alternatively, set the environment variable QC_API_KEY with your IBM Quantum Platform API key.
```

2. Better UX that the user does not need to restart the REPL/notebook to get the system to detect changes to the authentication setup because now we re-run the reading of the API token every time.
3. Unlock unit testing because now we don't have side effects at import-time.

The only downside is we call `read_api_key()` more times, which has a very minor performance cost, but it's negligible (reading env vars and the file system). Initializing `IAMAuth()` does not make network calls.