### PR TITLE
Simplify workflow for testing staging and local server

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,18 +60,53 @@ uv add <dependency> --dev
 
 ## Run the client
 
-1. Create a virtual environment and install the project with `pip install 'qc-grader[qiskit,jupyter] @ git+https://github.com/qiskit-community/Quantum-Challenge-Grader.git'` (or use `uv`)
-  - You can install from a specific branch by adding `@your-branch-name` to the end.
-2. Create an API token in https://quantum.cloud.ibm.com. The staging site will not work. The account must have at least one instance.
-  - You will need this token in the future. Consider saving it with `QiskitRuntimeService.save_account()` with these [instructions](https://quantum.cloud.ibm.com/docs/en/guides/hello-world)
-3. Launch a Python REPL inside the virtual environment with the environment variable `IBMCLOUD_API_KEY` set to your token.
-  - If you previously used `QiskitRuntimeService.save_account()`, you can find your token in `~/.qiskit/qiskit-ibm.json`
-4. In the REPL:
+Use this workflow to test the Python client against the Grader server.
+
+### Initial setup
+
+You must create a Quantum API token for an account with at least one instance.
+
+Prod server:
+
+1. Use https://quantum.cloud.ibm.com to create the API key
+2. Save the key by running `uv run python`, then this code:
+
+```python
+from qiskit_ibm_runtime import QiskitRuntimeService
+
+QiskitRuntimeService.save_account(
+    token="<your-api-key>",
+    instance="<CRN>",
+)
+```
+3. Close the REPL.
+
+Staging or local development server:
+
+1. Use https://quantum.test.cloud.ibm.com to create the API key.
+2. Save the key by running `uv run python`, then this code:
+
+```python
+from qiskit_ibm_runtime import QiskitRuntimeService
+
+QiskitRuntimeService.save_account(
+    token="<your-api-key>",
+    instance="<CRN>",
+    name="grader-staging",
+)
+```
+3. Close the REPL.
+
+### How to run
+
+1. Launch a Python REPL:
+  - Prod server: `uv run python`
+  - Staging server: `STAGING=1 uv run python`
+  - Local development server: `DEV=1 uv run python`
+2. In the REPL, import and run your exercises. For example:
 
 ```python
 >>> from qc_grader.challenges.test_challenge import submit_name, grade_ex1a
 >>> submit_name("team_name")  # use this value
 >>> grade_ex1a("")
 ```
-
-To use a different grading server, set `QC_GRADER_URL` to `https://qac-grading-dev.quantum.ibm.com` or `http://127.0.0.1:5000`. 

--- a/qc_grader/grader/api.py
+++ b/qc_grader/grader/api.py
@@ -15,9 +15,18 @@ from typing import Dict, Mapping, Optional
 
 from qc_grader import __version__
 
+IS_STAGING = os.environ.get("STAGING") == "1"
+IS_DEV = os.environ.get("DEV") == "1"
 
-GRADER_URL = os.environ.get("QC_GRADER_URL", "https://qac-grading.quantum.ibm.com")
-IAM_URL = os.environ.get("QC_IAM_URL", default="https://iam.cloud.ibm.com")
+if IS_STAGING:
+    GRADER_URL = "https://qac-grading-dev.quantum.ibm.com"
+    IAM_URL = "https://iam.test.cloud.ibm.com"
+elif IS_DEV:
+    GRADER_URL = "http://127.0.0.1:5000"
+    IAM_URL = "https://iam.test.cloud.ibm.com"
+else:
+    GRADER_URL = "https://qac-grading.quantum.ibm.com"
+    IAM_URL = "https://iam.cloud.ibm.com"
 
 
 def send_request(

--- a/qc_grader/grader/auth.py
+++ b/qc_grader/grader/auth.py
@@ -16,7 +16,7 @@ from ibm_cloud_sdk_core.authenticators import IAMAuthenticator
 from ibm_platform_services import IamIdentityV1
 from qiskit_ibm_runtime import QiskitRuntimeService
 
-from qc_grader.grader.api import IAM_URL
+from qc_grader.grader.api import IAM_URL, IS_STAGING, IS_DEV
 
 _AUTH_ENV_VAR_NAME = "QC_API_KEY"
 
@@ -33,7 +33,8 @@ def read_api_key() -> str | None:
     1. Read the legacy `IBMCLOUD_API_KEY` env var, with fallback to `saved_accounts().get("qdc-2025")`.
        We start with this to avoid breaking Road To Practioner users still using qdc-2025.
     2. Read the `QC_API_KEY` env var.
-    3. Read the default account with `saved_accounts()`.
+    3. If it's staging or local development, read `saved_accounts().get("grader-staging")`.
+    4. Read the default account with QiskitRuntimeService.
 
     Once qdc-2025 is no longer used, we can remove the legacy approach.
     """
@@ -43,6 +44,14 @@ def read_api_key() -> str | None:
         return key
     if key := os.environ.get(_AUTH_ENV_VAR_NAME):
         return key
+
+    if (IS_STAGING or IS_DEV) and (
+        key := QiskitRuntimeService.saved_accounts()
+        .get("grader-staging", {})
+        .get("token")
+    ):
+        return key
+
     if key := (QiskitRuntimeService().active_account() or {}).get("token"):
         return key
     return None


### PR DESCRIPTION
Closes https://github.com/qiskit-community/Quantum-Challenge-Grader/issues/258.

Both local development and staging use the test IAM server, which requires using an API key for the staging quantum site. So, this PR makes it easy to set up the staging account a single time by using `.save_account()` with a special name.