### PR TITLE
Change grade_lab0_ex3 to accept numpy array

### DIFF
--- a/qc_grader/challenges/qgss_2026/lab0.py
+++ b/qc_grader/challenges/qgss_2026/lab0.py
@@ -12,6 +12,7 @@
 QGSS 2026 Lab 0 - Grading Functions
 """
 
+import numpy as np
 from typeguard import typechecked
 
 from qiskit.quantum_info import Statevector
@@ -47,13 +48,15 @@ def grade_lab0_ex2(counts: dict[str, int]) -> None:
 
 
 @typechecked
-def grade_lab0_ex3(exp_val: float) -> None:
+def grade_lab0_ex3(exp_val: np.ndarray) -> None:
     """
     Grade Exercise 3: Verify Estimator result.
 
     Args:
-        exp_val: Expectation value from Estimator
+        exp_val: Expectation value from Estimator (numpy array)
     """
+    exp_val = float(exp_val)
+    
     grade(exp_val, "lab0-ex3", _CHALLENGE_ID)
 
 

--- a/qc_grader/challenges/qgss_2026/lab0.py
+++ b/qc_grader/challenges/qgss_2026/lab0.py
@@ -48,15 +48,15 @@ def grade_lab0_ex2(counts: dict[str, int]) -> None:
 
 
 @typechecked
-def grade_lab0_ex3(exp_val: np.ndarray) -> None:
+def grade_lab0_ex3(exp_val: np.ndarray | float) -> None:
     """
     Grade Exercise 3: Verify Estimator result.
 
     Args:
-        exp_val: Expectation value from Estimator (numpy array)
+        exp_val: Expectation value from Estimator (numpy array or float)
     """
     exp_val = float(exp_val)
-    
+
     grade(exp_val, "lab0-ex3", _CHALLENGE_ID)
 
 

--- a/qc_grader/challenges/qgss_2026/lab0.py
+++ b/qc_grader/challenges/qgss_2026/lab0.py
@@ -54,7 +54,7 @@ def grade_lab0_ex3(exp_val: np.ndarray | float) -> None:
     Args:
         exp_val: Expectation value from Estimator result[0].data.evs
                  Must be a scalar (0-d array or single float)
-    
+
     Raises:
         ValueError: If exp_val is not a scalar value
     """

--- a/qc_grader/challenges/qgss_2026/lab0.py
+++ b/qc_grader/challenges/qgss_2026/lab0.py
@@ -49,14 +49,22 @@ def grade_lab0_ex2(counts: dict[str, int]) -> None:
 
 @typechecked
 def grade_lab0_ex3(exp_val: np.ndarray | float) -> None:
-    """
-    Grade Exercise 3: Verify Estimator result.
+    """Grade Exercise 3: Verify Estimator result.
 
     Args:
-        exp_val: Expectation value from Estimator (numpy array or float)
+        exp_val: Expectation value from Estimator result[0].data.evs
+                 Must be a scalar (0-d array or single float)
+    
+    Raises:
+        ValueError: If exp_val is not a scalar value
     """
-    exp_val = float(exp_val)
-
+    arr = np.asarray(exp_val)
+    if arr.ndim != 0 and arr.size != 1:
+        raise ValueError(
+            f"exp_val must be a scalar, got shape {arr.shape}. "
+            f"Use result[0].data.evs (not result.data.evs) for a single expectation value."
+        )
+    exp_val = float(arr.flat[0])
     grade(exp_val, "lab0-ex3", _CHALLENGE_ID)
 
 


### PR DESCRIPTION
Updated the grade_lab0_ex3 function to accept a numpy array as input instead of a float and added a conversion to float within the function.