### PR TITLE
Improve type validation of qgss_2026 lab0 & document convention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,18 @@
+# Agents.md
+
+## About the project
+
+This project is a Python library for students to submit their answers to quantum computing challenges to a grader server. The server will return back whether the answer was correct or not.
+
+Users use this Python library through a REPL or Jupyter notebook, rather than a traditional Python program.
+
+Users are primarily students and are sometimes beginners to either programming or quantum computing. So, where reasonable, we try to make the program user-friendly, such as useful error messages.
+
+## Workflows
+
+Refer to the file `CONTRIBUTING.md` for instructions on how to run the project and extend it:
+
+* Run formatter
+* Run Ruff linter and ty type checker
+* Run Pytest tests
+* Add new labs and exercises

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,6 +118,9 @@ QiskitRuntimeService.save_account(
 You must add the decorator `@typechecked` from `typeguard` to all lab exercises, along with precise type hints that describe the user's input. This decorator validates that the user gave the correct data type. For example:
 
 ```python
+from typeguard import typechecked
+
+@typechecked
 def grade_lab0_ex1(arg1: str, arg2: list[int], arg3: QuantumCircuit) -> None:
     ...
 ```
@@ -127,8 +130,11 @@ If the user needs to provide a dictionary with certain keys, use `typing.TypedDi
 ```python
 from typing import TypedDict
 
+from typeguard import typechecked
+
 Ex1Input = TypedDict("Ex1Input", {"0": int, "1": int})
 
+@typechecked
 def grade_lab0_ex1(counts: Ex1Input) -> None:
     ...
 ```
@@ -136,6 +142,8 @@ def grade_lab0_ex1(counts: Ex1Input) -> None:
 It is often helpful to allow the user to provide a more flexible data type, and then to write some Python code to transform their input into a simpler format that the server will understand. When writing this type of transformation, think about how the user might make a mistake and consider adding validation, such as throwing a `ValueError` if they violate your assumptions. For example, this code is nice that it allows a user to either pass a `float` or an `ndarray`, which the code then transforms to `float` before sending to the server. This flexibility is useful because the challenge author knows that users will be working with NumPy for this exercise. Crucially, this example validates that their `ndarray` is a scalar:
 
 ```python
+from typeguard import typechecked
+
 @typechecked
 def grade_lab0_ex1(exp_val: np.ndarray | float) -> None:
     arr = np.asarray(exp_val)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,3 +110,40 @@ QiskitRuntimeService.save_account(
 >>> submit_name("team_name")  # use this value
 >>> grade_ex1a("")
 ```
+
+## Adding new labs
+
+### Type validation
+
+You must add the decorator `@typechecked` from `typeguard` to all lab exercises, along with precise type hints that describe the user's input. This decorator validates that the user gave the correct data type. For example:
+
+```python
+def grade_lab0_ex1(arg1: str, arg2: list[int], arg3: QuantumCircuit) -> None:
+    ...
+```
+
+If the user needs to provide a dictionary with certain keys, use `typing.TypedDict`, rather than a more generic type hint like `dict` or `dict[str, int]`. `TypedDict` allows typeguard to validate that the user gave the correct dictionary format. For example:
+
+```python
+from typing import TypedDict
+
+Ex1Input = TypedDict("Ex1Input", {"0": int, "1": int})
+
+def grade_lab0_ex1(counts: Ex1Input) -> None:
+    ...
+```
+
+It is often helpful to allow the user to provide a more flexible data type, and then to write some Python code to transform their input into a simpler format that the server will understand. When writing this type of transformation, think about how the user might make a mistake and consider adding validation, such as throwing a `ValueError` if they violate your assumptions. For example, this code is nice that it allows a user to either pass a `float` or an `ndarray`, which the code then transforms to `float` before sending to the server. This flexibility is useful because the challenge author knows that users will be working with NumPy for this exercise. Crucially, this example validates that their `ndarray` is a scalar:
+
+```python
+@typechecked
+def grade_lab0_ex1(exp_val: np.ndarray | float) -> None:
+    arr = np.asarray(exp_val)
+    if arr.ndim != 0 and arr.size != 1:
+        raise ValueError(
+            f"exp_val must be a scalar, got shape {arr.shape}. "
+            f"Use result[0].data.evs (not result.data.evs) for a single expectation value."
+        )
+    exp_val = float(arr.flat[0])
+    grade(exp_val, "lab0-ex1", _CHALLENGE_ID)
+```

--- a/qc_grader/challenges/qgss_2026/lab0.py
+++ b/qc_grader/challenges/qgss_2026/lab0.py
@@ -13,6 +13,7 @@ QGSS 2026 Lab 0 - Grading Functions
 """
 
 import numpy as np
+from typing import TypedDict
 from typeguard import typechecked
 
 from qiskit.quantum_info import Statevector
@@ -36,8 +37,11 @@ def grade_lab0_ex1() -> None:
     grade("hello", "lab0-ex1", _CHALLENGE_ID)
 
 
+Ex2Input = TypedDict("Ex2Input", {"0": int, "1": int})
+
+
 @typechecked
-def grade_lab0_ex2(counts: dict[str, int]) -> None:
+def grade_lab0_ex2(counts: Ex2Input) -> None:
     """
     Grade Exercise 2: Verify sampler result.
 


### PR DESCRIPTION
Closes https://github.com/qiskit-community/Quantum-Challenge-Grader/issues/293. 

Turns out, `typeguard` is already really good at validating that the user is giving us valid inputs. For example, it understands `list[str]` vs `list[int]`. The key is that we need to give typeguard good type hints for it to check things, like `list[int]` rather than `list`.

With dictionaries, we should use `TypedDict` when we need the user to define specific keys, such as `{"0": 84, "1": 200}`.

I didn't update qdc_2025 because I don't understand that challenge well; it's also actually doing things pretty well to begin with. The focus is on making sure we do type validation well in the future.

--

Some example typeguard errors:

```
typeguard.TypeCheckError: item 0 of argument "c_out" (list) is not an instance of str
```
```
typeguard.TypeCheckError: argument "counts" (dict) is missing required key(s): "0", "1"
```
```
typeguard.TypeCheckError: argument "exp_val" (str) did not match any element in the union:
  numpy.ndarray: is not an instance of numpy.ndarray
  float: is neither float or int
```

--

This PR also updates the contributor guide with our expectations for type validation. It sets up a minimal AGENTS.md to increase the odds that AI agents follow our expectations.