### PR TITLE
Enforce SSL when getting bearer token

### DIFF
--- a/qc_grader/grader/auth.py
+++ b/qc_grader/grader/auth.py
@@ -67,10 +67,10 @@ def get_access_token() -> str:
             + f"{_AUTH_ENV_VAR_NAME} with your IBM Quantum Platform API key."
         ).with_traceback(None)
 
-    authenticator = IAMAuthenticator(api_key, url=f"{IAM_URL}/identity/token")
-
     try:
-        return authenticator.token_manager.get_token()
+        return IAMAuthenticator(
+            api_key, url=f"{IAM_URL}/identity/token"
+        ).token_manager.get_token()
     except Exception:
         raise AuthenticationError(
             "An authentication token could not be generated from your IBM Quantum Platform API key. Usually, "

--- a/qc_grader/grader/auth.py
+++ b/qc_grader/grader/auth.py
@@ -67,9 +67,7 @@ def get_access_token() -> str:
             + f"{_AUTH_ENV_VAR_NAME} with your IBM Quantum Platform API key."
         ).with_traceback(None)
 
-    authenticator = IAMAuthenticator(
-        api_key, url=f"{IAM_URL}/identity/token", disable_ssl_verification=True
-    )
+    authenticator = IAMAuthenticator(api_key, url=f"{IAM_URL}/identity/token")
 
     try:
         return authenticator.token_manager.get_token()


### PR DESCRIPTION
Closes https://github.com/qiskit-community/Quantum-Challenge-Grader/issues/294.

I tested I can still authenticate by using the workflow in `CONTRIBUTING.md`. (This change specifically impacts the _client_ getting a bearer token to send to the server.)

This SSL code was originally configured to work around an issue we were having with Jupyter notebooks. I couldn't figure out what that issue was, but either way, the workaround was not acceptable from a security perspective. If this issue comes up again, we will have to find some other way to fix the SSL issues.