### PR TITLE
Remove unused ipywidgets codepath

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,6 @@ qiskit = [
 jupyter = [
     "jupyterlab",
     "ipykernel",
-    "ipywidgets",
 ]
 
 [dependency-groups]

--- a/qc_grader/grader/grade.py
+++ b/qc_grader/grader/grade.py
@@ -61,27 +61,14 @@ def grade_answer(
         return False, None, str(err)
 
 
-def display_special_message(message: str, preamble="") -> None:
-    if message.startswith("data:image/"):
-        from IPython.display import display
-        from ipywidgets import HTML
-
-        print(preamble)
-        display(HTML(f'<img src="{message}" />'))
-    else:
-        print(message)
-
-
 def handle_grade_response(
     status: Optional[str],
-    score: Optional[Union[int, float]] = None,
-    cause: Optional[str] = None,
+    score: Optional[Union[int, float]],
+    cause: Optional[str],
 ) -> None:
-    if status == "valid" or status is True:
+    if status == "valid":
         if cause is not None:
-            display_special_message(
-                cause, preamble="\nCongratulations 🎉! Your answer is correct."
-            )
+            print(cause)
         else:
             print("\nCongratulations 🎉! Your answer is correct.")
         if score is not None:
@@ -89,9 +76,6 @@ def handle_grade_response(
     elif status == "invalid":
         print(f"\nOops 😕! {'Your answer is incorrect' if cause is None else cause}")
         print("Please review your answer and try again.")
-    elif status == "notFinished":
-        print(f"Job has not finished: {cause}")
-        print("Please wait for the job to complete then try again.")
     else:
         print(f"Failed: {cause}")
         print("Unable to grade your answer.")

--- a/uv.lock
+++ b/uv.lock
@@ -909,22 +909,6 @@ wheels = [
 ]
 
 [[package]]
-name = "ipywidgets"
-version = "8.1.8"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "comm" },
-    { name = "ipython" },
-    { name = "jupyterlab-widgets" },
-    { name = "traitlets" },
-    { name = "widgetsnbextension" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/4c/ae/c5ce1edc1afe042eadb445e95b0671b03cee61895264357956e61c0d2ac0/ipywidgets-8.1.8.tar.gz", hash = "sha256:61f969306b95f85fba6b6986b7fe45d73124d1d9e3023a8068710d47a22ea668", size = 116739, upload-time = "2025-11-01T21:18:12.393Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/56/6d/0d9848617b9f753b87f214f1c682592f7ca42de085f564352f10f0843026/ipywidgets-8.1.8-py3-none-any.whl", hash = "sha256:ecaca67aed704a338f88f67b1181b58f821ab5dc89c1f0f5ef99db43c1c2921e", size = 139808, upload-time = "2025-11-01T21:18:10.956Z" },
-]
-
-[[package]]
 name = "isoduration"
 version = "20.11.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1171,15 +1155,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d6/2c/90153f189e421e93c4bb4f9e3f59802a1f01abd2ac5cf40b152d7f735232/jupyterlab_server-2.28.0.tar.gz", hash = "sha256:35baa81898b15f93573e2deca50d11ac0ae407ebb688299d3a5213265033712c", size = 76996, upload-time = "2025-10-22T13:59:18.37Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/07/a000fe835f76b7e1143242ab1122e6362ef1c03f23f83a045c38859c2ae0/jupyterlab_server-2.28.0-py3-none-any.whl", hash = "sha256:e4355b148fdcf34d312bbbc80f22467d6d20460e8b8736bf235577dd18506968", size = 59830, upload-time = "2025-10-22T13:59:16.767Z" },
-]
-
-[[package]]
-name = "jupyterlab-widgets"
-version = "3.0.16"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/26/2d/ef58fed122b268c69c0aa099da20bc67657cdfb2e222688d5731bd5b971d/jupyterlab_widgets-3.0.16.tar.gz", hash = "sha256:423da05071d55cf27a9e602216d35a3a65a3e41cdf9c5d3b643b814ce38c19e0", size = 897423, upload-time = "2025-11-01T21:11:29.724Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ab/b5/36c712098e6191d1b4e349304ef73a8d06aed77e56ceaac8c0a306c7bda1/jupyterlab_widgets-3.0.16-py3-none-any.whl", hash = "sha256:45fa36d9c6422cf2559198e4db481aa243c7a32d9926b500781c830c80f7ecf8", size = 914926, upload-time = "2025-11-01T21:11:28.008Z" },
 ]
 
 [[package]]
@@ -2563,7 +2538,6 @@ dependencies = [
 [package.optional-dependencies]
 jupyter = [
     { name = "ipykernel" },
-    { name = "ipywidgets" },
     { name = "jupyterlab" },
 ]
 qiskit = [
@@ -2583,7 +2557,6 @@ dev = [
 requires-dist = [
     { name = "ibm-platform-services", specifier = "==0.66.1" },
     { name = "ipykernel", marker = "extra == 'jupyter'" },
-    { name = "ipywidgets", marker = "extra == 'jupyter'" },
     { name = "jupyterlab", marker = "extra == 'jupyter'" },
     { name = "moocore" },
     { name = "networkx", specifier = "==3.2.1" },
@@ -3428,13 +3401,4 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/2c/41/aa4bf9664e4cda14c3b39865b12251e8e7d239f4cd0e3cc1b6c2ccde25c1/websocket_client-1.9.0.tar.gz", hash = "sha256:9e813624b6eb619999a97dc7958469217c3176312b3a16a4bd1bc7e08a46ec98", size = 70576, upload-time = "2025-10-07T21:16:36.495Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl", hash = "sha256:af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef", size = 82616, upload-time = "2025-10-07T21:16:34.951Z" },
-]
-
-[[package]]
-name = "widgetsnbextension"
-version = "4.0.15"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/bd/f4/c67440c7fb409a71b7404b7aefcd7569a9c0d6bd071299bf4198ae7a5d95/widgetsnbextension-4.0.15.tar.gz", hash = "sha256:de8610639996f1567952d763a5a41af8af37f2575a41f9852a38f947eb82a3b9", size = 1097402, upload-time = "2025-11-01T21:15:55.178Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/0e/fa3b193432cfc60c93b42f3be03365f5f909d2b3ea410295cf36df739e31/widgetsnbextension-4.0.15-py3-none-any.whl", hash = "sha256:8156704e4346a571d9ce73b84bee86a29906c9abfd7223b7228a28899ccf3366", size = 2196503, upload-time = "2025-11-01T21:15:53.565Z" },
 ]


### PR DESCRIPTION
Part of https://github.com/qiskit-community/Quantum-Challenge-Grader/issues/264.

This removed code path never actually triggered in our codebase. There was a bug in the server that prevented a challenge from returning the status as `valid` along with giving a `cause`.

Even if this removed code path had been triggered, the `cause` never included images, and we don't plan to add that feature. We only want to return simple strings.