### PR TITLE
Split out submit_team_name function

### DIFF
--- a/qc_grader/challenges/qdc_2025/qdc25_lab2.py
+++ b/qc_grader/challenges/qdc_2025/qdc25_lab2.py
@@ -11,7 +11,7 @@
 from typeguard import typechecked
 
 from qiskit import QuantumCircuit
-from qc_grader.grader.grade import grade
+from qc_grader.grader.grade import grade, submit_team_name
 from qiskit_ibm_runtime.ibm_backend import IBMBackend
 from qiskit_ibm_runtime import EstimatorV2
 from typing import List
@@ -24,33 +24,27 @@ from qiskit.primitives.containers.primitive_result import PrimitiveResult
 from qiskit.quantum_info import SparsePauliOp
 
 
-_challenge_id = "qdc_2025"
+_CHALLENGE_ID = "qdc_2025"
 
 
 @typechecked
 def submit_name(name: str) -> None:
-    status, score, message = grade(
-        name, "submit-name", _challenge_id, return_response=True
-    )
-    if status is False:
-        print(message)
-    else:
-        print("Team name submitted.")
+    submit_team_name(name, _CHALLENGE_ID)
 
 
 @typechecked
 def grade_lab2_ex1(observables: List) -> None:
-    grade(observables, "lab2-ex1", _challenge_id)
+    grade(observables, "lab2-ex1", _CHALLENGE_ID)
 
 
 @typechecked
 def grade_lab2_ex2(qc: QuantumCircuit) -> None:
-    grade(qc, "lab2-ex2", _challenge_id)
+    grade(qc, "lab2-ex2", _CHALLENGE_ID)
 
 
 @typechecked
 def grade_lab2_ex3(qc: QuantumCircuit) -> None:
-    grade(qc, "lab2-ex3", _challenge_id)
+    grade(qc, "lab2-ex3", _CHALLENGE_ID)
 
 
 @typechecked
@@ -67,7 +61,7 @@ def grade_lab2_ex4(
         "qc_vacuum_test": qc_vacuum_test,
         "qc_vacuum_mitig_test": qc_vacuum_mitig_test,
     }
-    grade(answer_dict, "lab2-ex4", _challenge_id)
+    grade(answer_dict, "lab2-ex4", _CHALLENGE_ID)
 
 
 @typechecked
@@ -77,7 +71,7 @@ def grade_lab2_ex5(backend: IBMBackend) -> None:
     else:
         answer = "false"
 
-    grade(answer, "lab2-ex5", _challenge_id)
+    grade(answer, "lab2-ex5", _CHALLENGE_ID)
 
 
 @typechecked
@@ -86,7 +80,7 @@ def grade_lab2_ex7(estimator: EstimatorV2) -> None:
         answer = "false"
     else:
         answer = "true"
-    grade(answer, "lab2-ex7", _challenge_id)
+    grade(answer, "lab2-ex7", _CHALLENGE_ID)
 
 
 @typechecked
@@ -101,7 +95,7 @@ def grade_lab2_ex8(
         "circuits_all_isa": circuits_all_isa[:1],
         "observables_isa": observables_isa,
     }
-    grade(answer_dict, "lab2-ex8", _challenge_id)
+    grade(answer_dict, "lab2-ex8", _CHALLENGE_ID)
 
 
 @typechecked
@@ -113,7 +107,7 @@ def grade_lab2_ex9(job: RuntimeJobV2) -> None:
         "job_inputs": len(job.inputs["pubs"]),
     }
 
-    grade(answer_dict, "lab2-ex9", _challenge_id)
+    grade(answer_dict, "lab2-ex9", _CHALLENGE_ID)
 
 
 @typechecked
@@ -142,7 +136,7 @@ def grade_lab2_ex10(
         "results": results_list,
     }
 
-    grade(answer_dict, "lab2-ex10", _challenge_id)
+    grade(answer_dict, "lab2-ex10", _CHALLENGE_ID)
 
 
 @typechecked
@@ -160,9 +154,9 @@ def grade_lab2_ex11(
         "chi_vacuum": chi_vacuum,
     }
 
-    grade(answer_dict, "lab2-ex11", _challenge_id)
+    grade(answer_dict, "lab2-ex11", _CHALLENGE_ID)
 
 
 @typechecked
 def grade_lab2_ex12(chi_final: np.ndarray) -> None:
-    grade(chi_final, "lab2-ex12", _challenge_id)
+    grade(chi_final, "lab2-ex12", _CHALLENGE_ID)

--- a/qc_grader/challenges/qdc_2025/qdc25_lab5.py
+++ b/qc_grader/challenges/qdc_2025/qdc25_lab5.py
@@ -11,7 +11,7 @@
 from typeguard import typechecked
 
 from qiskit import QuantumCircuit
-from qc_grader.grader.grade import grade
+from qc_grader.grader.grade import grade, submit_team_name
 from typeguard import check_type
 import numpy as np
 from datetime import datetime
@@ -22,18 +22,12 @@ from .qmoo_files import load_problem
 from typing import Callable
 
 
-_challenge_id = "qdc_2025"
+_CHALLENGE_ID = "qdc_2025"
 
 
 @typechecked
 def submit_name(name: str) -> None:
-    status, score, message = grade(
-        name, "submit-name", _challenge_id, return_response=True
-    )
-    if status is False:
-        print(message)
-    else:
-        print("Team name submitted.")
+    submit_team_name(name, _CHALLENGE_ID)
 
 
 @typechecked
@@ -61,21 +55,21 @@ def grade_lab5_ex1(gen_cvecs: Callable) -> None:
             samples.append(v)
 
     answer_dict = {"samples": samples}
-    grade(answer_dict, "lab5-ex1", _challenge_id)
+    grade(answer_dict, "lab5-ex1", _CHALLENGE_ID)
 
 
 @typechecked
 def grade_lab5_ex2(user_hv: float) -> None:
     check_type(user_hv, float)
     answer_dict = {"user_hv": user_hv}
-    grade(answer_dict, "lab5-ex2", _challenge_id)
+    grade(answer_dict, "lab5-ex2", _CHALLENGE_ID)
 
 
 @typechecked
 def grade_lab5_ex3(qc: QuantumCircuit) -> None:
     check_type(qc, QuantumCircuit)
     answer_dict = {"qc": qc}
-    grade(answer_dict, "lab5-ex3", _challenge_id)
+    grade(answer_dict, "lab5-ex3", _CHALLENGE_ID)
 
 
 @typechecked
@@ -133,4 +127,4 @@ def grade_lab_5_ex4(
     answer_dict = {
         "user_hv": user_hv,
     }
-    grade(answer_dict, "lab5-ex4", _challenge_id)
+    grade(answer_dict, "lab5-ex4", _CHALLENGE_ID)

--- a/qc_grader/challenges/qdc_2025/qdc25_lab6.py
+++ b/qc_grader/challenges/qdc_2025/qdc25_lab6.py
@@ -10,20 +10,14 @@
 
 from typeguard import typechecked, check_type
 
-from qc_grader.grader.grade import grade
+from qc_grader.grader.grade import grade, submit_team_name
 
-_challenge_id = "qdc_2025"
+_CHALLENGE_ID = "qdc_2025"
 
 
 @typechecked
 def submit_name(name: str) -> None:
-    status, score, message = grade(
-        name, "submit-name", _challenge_id, return_response=True
-    )
-    if status is False:
-        print(message)
-    else:
-        print("Team name submitted.")
+    submit_team_name(name, _CHALLENGE_ID)
 
 
 @typechecked
@@ -34,7 +28,7 @@ def grade_lab6_ex1(molecule_name: str, hartree_fock_E: float) -> None:
         "hartree_fock_E": hartree_fock_E,
     }
 
-    grade(answer_dict, "lab6-ex1", _challenge_id)
+    grade(answer_dict, "lab6-ex1", _CHALLENGE_ID)
 
 
 @typechecked
@@ -42,7 +36,7 @@ def grade_lab6_ex2(molecule_name: str, casci_E: float) -> None:
 
     answer_dict = {"molecule_name": molecule_name, "casci_E": casci_E}
 
-    grade(answer_dict, "lab6-ex2", _challenge_id)
+    grade(answer_dict, "lab6-ex2", _CHALLENGE_ID)
 
 
 @typechecked
@@ -55,4 +49,4 @@ def grade_lab6_ex3(molecule_name: str, sqd_E: list) -> None:
 
     answer_dict = {"molecule_name": molecule_name, "sqd_E": sqd_E}
 
-    grade(answer_dict, "lab6-ex3", _challenge_id)
+    grade(answer_dict, "lab6-ex3", _CHALLENGE_ID)

--- a/qc_grader/challenges/test_challenge/exercise1.py
+++ b/qc_grader/challenges/test_challenge/exercise1.py
@@ -11,38 +11,32 @@
 from pathlib import Path
 from typeguard import typechecked
 
-from qc_grader.grader.grade import grade
+from qc_grader.grader.grade import grade, submit_team_name
 
 
-challenge_id = Path(__file__).parent.name
+_CHALLENGE_ID = Path(__file__).parent.name
 
 
 @typechecked
 def submit_name(name: str) -> None:
-    status, score, message = grade(
-        name, "submit-name", challenge_id, return_response=True
-    )
-    if status is False:
-        print(message)
-    else:
-        print("Team name submitted.")
+    submit_team_name(name, _CHALLENGE_ID)
 
 
 @typechecked
 def grade_ex1a(answer: str) -> None:
-    grade(answer, "test-pass", challenge_id)
+    grade(answer, "test-pass", _CHALLENGE_ID)
 
 
 @typechecked
 def grade_ex1b(answer: str) -> None:
-    grade(answer, "test-fail", challenge_id)
+    grade(answer, "test-fail", _CHALLENGE_ID)
 
 
 @typechecked
 def grade_ex1c(answer: int) -> None:
-    grade(answer, "test-prime", challenge_id)
+    grade(answer, "test-prime", _CHALLENGE_ID)
 
 
 @typechecked
 def grade_ex1d(answer: str) -> None:
-    grade(answer, "test-vowels", challenge_id)
+    grade(answer, "test-vowels", _CHALLENGE_ID)

--- a/qc_grader/challenges/test_challenge/exercise2.py
+++ b/qc_grader/challenges/test_challenge/exercise2.py
@@ -16,9 +16,9 @@ from qiskit import QuantumCircuit
 from qc_grader.grader.grade import grade
 
 
-challenge_id = Path(__file__).parent.name
+_CHALLENGE_ID = Path(__file__).parent.name
 
 
 @typechecked
 def grade_ex2a(qc: QuantumCircuit) -> None:
-    grade(qc, "test-circuit", challenge_id)
+    grade(qc, "test-circuit", _CHALLENGE_ID)

--- a/qc_grader/grader/api.py
+++ b/qc_grader/grader/api.py
@@ -14,6 +14,7 @@ import requests
 from typing import Dict, Mapping, Optional
 
 from qc_grader import __version__
+from qc_grader.grader.auth import get_access_token
 
 IS_STAGING = os.environ.get("STAGING") == "1"
 IS_DEV = os.environ.get("DEV") == "1"
@@ -40,6 +41,7 @@ def send_request(
         "Accept": "application/json",
         "Content-Type": "application/json",
         "X-Client-Version": __version__,
+        "Authorization": f"Bearer {get_access_token()}",
     }
     additional_header = header or {}
     header = {**default_header, **additional_header}

--- a/qc_grader/grader/grade.py
+++ b/qc_grader/grader/grade.py
@@ -8,57 +8,53 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Any, Optional, Union
 
 
 from qc_grader.custom_encoder import to_json
-from qc_grader.grader.auth import get_access_token
 
 from .api import GRADER_URL, send_request
 
 
-def grade(
-    answer: Any,
-    question: str,
-    challenge: str,
-    return_response: Optional[bool] = False,
-) -> Tuple[bool, Optional[Union[str, int, float]], Optional[Union[str, int, float]]]:  # ty: ignore[invalid-return-type]
-    endpoint = f"{GRADER_URL}/challenges/{challenge}/validate/{question}"
-    payload = {"answer": to_json(answer)}
+def submit_team_name(answer: str, challenge_id: str) -> None:
+    """Send the team name to the validate endpoint's submit-name question and print the result."""
+
+    print("Submitting your team name. Please wait...")
+    try:
+        answer_response = send_request(
+            f"{GRADER_URL}/challenges/{challenge_id}/validate/submit-name",
+            body={"answer": to_json(answer)},
+        )
+    except Exception as e:
+        print(f"Failed: {e}")
+        return
+
+    if answer_response.get("status") == "valid":
+        print("🎉 Team name submitted.")
+        return
+
+    cause = answer_response.get("cause")
+    print(f"Failed to submit team name. {'' if cause is None else cause}")
+
+
+def grade(answer: Any, question: str, challenge: str) -> None:
+    """Send the answer to the validate endpoint and print the result."""
 
     print("Grading your answer. Please wait...")
-    result = grade_answer(
-        payload,
-        endpoint,
-        return_response=return_response,
-    )
-
-    if return_response:
-        return result
-
-
-def grade_answer(
-    payload: Dict[str, str],
-    endpoint: str,
-    return_response: Optional[bool] = False,
-) -> Tuple[bool, Optional[Union[str, int, float]], Optional[Union[str, int, float]]]:  # ty: ignore[invalid-return-type]
     try:
-        header = {"Authorization": f"Bearer {get_access_token()}"}
-        answer_response = send_request(endpoint, body=payload, header=header)
+        answer_response = send_request(
+            f"{GRADER_URL}/challenges/{challenge}/validate/{question}",
+            body={"answer": to_json(answer)},
+        )
+    except Exception as e:
+        print(f"Failed: {e}")
+        return
 
-        status = answer_response.get("status", None)
-        cause = answer_response.get("cause", None)
-        score = answer_response.get("score", None)
-
-        if return_response:
-            s = status == "valid" or status is True
-            return s, score, cause
-
-        handle_grade_response(status, score=score, cause=cause)  # ty: ignore[invalid-argument-type]
-
-    except Exception as err:
-        print(f"Failed: {err}")
-        return False, None, str(err)
+    handle_grade_response(
+        answer_response.get("status"),
+        score=answer_response.get("score"),  # ty: ignore[invalid-argument-type]
+        cause=answer_response.get("cause"),
+    )
 
 
 def display_special_message(message: str, preamble="") -> None:


### PR DESCRIPTION
Closes https://github.com/qiskit-community/Quantum-Challenge-Grader/issues/287.

Our server unfortunately reuses `/challenges/<challenge-id>/validate/<question-id>` for two different purposes:

* Submitting the user's team name, which associates in the DB the user ID with the team
* Validating an exercise

We cannot easily split out the endpoint into two because of backwards compatibility. However, we at least can make the code more clear. So, this PR adds the `submit_team_name` helper.

By splitting out `submit_team_name`, we can simplify `grade` to remove `return_response`. That makes the function much simpler, such that we inline `grade_answer` into `grade.