### PR TITLE
Clean up data modeling for lab vs exercise

### DIFF
--- a/qc_grader/challenges/qdc_2025/qdc25_lab2.py
+++ b/qc_grader/challenges/qdc_2025/qdc25_lab2.py
@@ -8,23 +8,26 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-from typeguard import typechecked
-
-from qiskit import QuantumCircuit
-from qc_grader.grader.grade import grade, submit_team_name
-from qiskit_ibm_runtime.ibm_backend import IBMBackend
-from qiskit_ibm_runtime import EstimatorV2
-from typing import List
+from typing import Any, List
 
 import numpy as np
-
 import qiskit_ibm_runtime
-from qiskit_ibm_runtime.runtime_job_v2 import RuntimeJobV2
+from qiskit import QuantumCircuit
 from qiskit.primitives.containers.primitive_result import PrimitiveResult
 from qiskit.quantum_info import SparsePauliOp
+from qiskit_ibm_runtime import EstimatorV2
+from qiskit_ibm_runtime.ibm_backend import IBMBackend
+from qiskit_ibm_runtime.runtime_job_v2 import RuntimeJobV2
+from typeguard import typechecked
 
+from qc_grader.grader.grade import grade_answer, submit_team_name
 
 _CHALLENGE_ID = "qdc_2025"
+_LAB_ID = "lab2"
+
+
+def _grade(answer: Any, exercise: str) -> None:
+    grade_answer(answer, lab=_LAB_ID, exercise=exercise, challenge=_CHALLENGE_ID)
 
 
 @typechecked
@@ -34,17 +37,17 @@ def submit_name(name: str) -> None:
 
 @typechecked
 def grade_lab2_ex1(observables: List) -> None:
-    grade(observables, "lab2-ex1", _CHALLENGE_ID)
+    _grade(observables, "ex1")
 
 
 @typechecked
 def grade_lab2_ex2(qc: QuantumCircuit) -> None:
-    grade(qc, "lab2-ex2", _CHALLENGE_ID)
+    _grade(qc, "ex2")
 
 
 @typechecked
 def grade_lab2_ex3(qc: QuantumCircuit) -> None:
-    grade(qc, "lab2-ex3", _CHALLENGE_ID)
+    _grade(qc, "ex3")
 
 
 @typechecked
@@ -61,7 +64,7 @@ def grade_lab2_ex4(
         "qc_vacuum_test": qc_vacuum_test,
         "qc_vacuum_mitig_test": qc_vacuum_mitig_test,
     }
-    grade(answer_dict, "lab2-ex4", _CHALLENGE_ID)
+    _grade(answer_dict, "ex4")
 
 
 @typechecked
@@ -71,7 +74,7 @@ def grade_lab2_ex5(backend: IBMBackend) -> None:
     else:
         answer = "false"
 
-    grade(answer, "lab2-ex5", _CHALLENGE_ID)
+    _grade(answer, "ex5")
 
 
 @typechecked
@@ -80,7 +83,7 @@ def grade_lab2_ex7(estimator: EstimatorV2) -> None:
         answer = "false"
     else:
         answer = "true"
-    grade(answer, "lab2-ex7", _CHALLENGE_ID)
+    _grade(answer, "ex7")
 
 
 @typechecked
@@ -95,7 +98,7 @@ def grade_lab2_ex8(
         "circuits_all_isa": circuits_all_isa[:1],
         "observables_isa": observables_isa,
     }
-    grade(answer_dict, "lab2-ex8", _CHALLENGE_ID)
+    _grade(answer_dict, "ex8")
 
 
 @typechecked
@@ -107,7 +110,7 @@ def grade_lab2_ex9(job: RuntimeJobV2) -> None:
         "job_inputs": len(job.inputs["pubs"]),
     }
 
-    grade(answer_dict, "lab2-ex9", _CHALLENGE_ID)
+    _grade(answer_dict, "ex9")
 
 
 @typechecked
@@ -136,7 +139,7 @@ def grade_lab2_ex10(
         "results": results_list,
     }
 
-    grade(answer_dict, "lab2-ex10", _CHALLENGE_ID)
+    _grade(answer_dict, "ex10")
 
 
 @typechecked
@@ -154,9 +157,9 @@ def grade_lab2_ex11(
         "chi_vacuum": chi_vacuum,
     }
 
-    grade(answer_dict, "lab2-ex11", _CHALLENGE_ID)
+    _grade(answer_dict, "ex11")
 
 
 @typechecked
 def grade_lab2_ex12(chi_final: np.ndarray) -> None:
-    grade(chi_final, "lab2-ex12", _CHALLENGE_ID)
+    _grade(chi_final, "ex12")

--- a/qc_grader/challenges/qdc_2025/qdc25_lab5.py
+++ b/qc_grader/challenges/qdc_2025/qdc25_lab5.py
@@ -8,21 +8,26 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-from typeguard import typechecked
-
-from qiskit import QuantumCircuit
-from qc_grader.grader.grade import grade, submit_team_name
-from typeguard import check_type
-import numpy as np
-from datetime import datetime
 import pickle
-from moocore import hypervolume
-import networkx as nx
-from .qmoo_files import load_problem
-from typing import Callable
+from datetime import datetime
+from typing import Any, Callable
 
+import networkx as nx
+import numpy as np
+from moocore import hypervolume
+from qiskit import QuantumCircuit
+from typeguard import check_type, typechecked
+
+from qc_grader.grader.grade import grade_answer, submit_team_name
+
+from .qmoo_files import load_problem
 
 _CHALLENGE_ID = "qdc_2025"
+_LAB_ID = "lab5"
+
+
+def _grade(answer: Any, exercise: str) -> None:
+    grade_answer(answer, lab=_LAB_ID, exercise=exercise, challenge=_CHALLENGE_ID)
 
 
 @typechecked
@@ -55,21 +60,21 @@ def grade_lab5_ex1(gen_cvecs: Callable) -> None:
             samples.append(v)
 
     answer_dict = {"samples": samples}
-    grade(answer_dict, "lab5-ex1", _CHALLENGE_ID)
+    _grade(answer_dict, "ex1")
 
 
 @typechecked
 def grade_lab5_ex2(user_hv: float) -> None:
     check_type(user_hv, float)
     answer_dict = {"user_hv": user_hv}
-    grade(answer_dict, "lab5-ex2", _CHALLENGE_ID)
+    _grade(answer_dict, "ex2")
 
 
 @typechecked
 def grade_lab5_ex3(qc: QuantumCircuit) -> None:
     check_type(qc, QuantumCircuit)
     answer_dict = {"qc": qc}
-    grade(answer_dict, "lab5-ex3", _CHALLENGE_ID)
+    _grade(answer_dict, "ex3")
 
 
 @typechecked
@@ -127,4 +132,4 @@ def grade_lab_5_ex4(
     answer_dict = {
         "user_hv": user_hv,
     }
-    grade(answer_dict, "lab5-ex4", _CHALLENGE_ID)
+    _grade(answer_dict, "ex4")

--- a/qc_grader/challenges/qdc_2025/qdc25_lab6.py
+++ b/qc_grader/challenges/qdc_2025/qdc25_lab6.py
@@ -8,11 +8,18 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-from typeguard import typechecked, check_type
+from typing import Any
 
-from qc_grader.grader.grade import grade, submit_team_name
+from typeguard import check_type, typechecked
+
+from qc_grader.grader.grade import grade_answer, submit_team_name
 
 _CHALLENGE_ID = "qdc_2025"
+_LAB_ID = "lab6"
+
+
+def _grade(answer: Any, exercise: str) -> None:
+    grade_answer(answer, lab=_LAB_ID, exercise=exercise, challenge=_CHALLENGE_ID)
 
 
 @typechecked
@@ -28,7 +35,7 @@ def grade_lab6_ex1(molecule_name: str, hartree_fock_E: float) -> None:
         "hartree_fock_E": hartree_fock_E,
     }
 
-    grade(answer_dict, "lab6-ex1", _CHALLENGE_ID)
+    _grade(answer_dict, "ex1")
 
 
 @typechecked
@@ -36,7 +43,7 @@ def grade_lab6_ex2(molecule_name: str, casci_E: float) -> None:
 
     answer_dict = {"molecule_name": molecule_name, "casci_E": casci_E}
 
-    grade(answer_dict, "lab6-ex2", _CHALLENGE_ID)
+    _grade(answer_dict, "ex2")
 
 
 @typechecked
@@ -49,4 +56,4 @@ def grade_lab6_ex3(molecule_name: str, sqd_E: list) -> None:
 
     answer_dict = {"molecule_name": molecule_name, "sqd_E": sqd_E}
 
-    grade(answer_dict, "lab6-ex3", _CHALLENGE_ID)
+    _grade(answer_dict, "ex3")

--- a/qc_grader/challenges/qgss_2026/lab0.py
+++ b/qc_grader/challenges/qgss_2026/lab0.py
@@ -12,14 +12,20 @@
 QGSS 2026 Lab 0 - Grading Functions
 """
 
+from typing import Any, TypedDict
+
 import numpy as np
-from typing import TypedDict
+from qiskit.quantum_info import Statevector
 from typeguard import typechecked
 
-from qiskit.quantum_info import Statevector
-from qc_grader.grader.grade import grade
+from qc_grader.grader.grade import grade_answer
 
 _CHALLENGE_ID = "qgss_2026"
+_LAB_ID = "lab0"
+
+
+def _grade(answer: Any, exercise: str) -> None:
+    grade_answer(answer, lab=_LAB_ID, exercise=exercise, challenge=_CHALLENGE_ID)
 
 
 def grade_lab0_ex1() -> None:
@@ -34,7 +40,7 @@ def grade_lab0_ex1() -> None:
     Simply call this function with no arguments:
         grade_lab0_ex1()
     """
-    grade("hello", "lab0-ex1", _CHALLENGE_ID)
+    _grade("hello", "ex1")
 
 
 Ex2Input = TypedDict("Ex2Input", {"0": int, "1": int})
@@ -48,7 +54,7 @@ def grade_lab0_ex2(counts: Ex2Input) -> None:
     Args:
         counts: Dictionary of measurement counts
     """
-    grade(counts, "lab0-ex2", _CHALLENGE_ID)
+    _grade(counts, "ex2")
 
 
 @typechecked
@@ -69,7 +75,7 @@ def grade_lab0_ex3(exp_val: np.ndarray | float) -> None:
             f"Use result[0].data.evs (not result.data.evs) for a single expectation value."
         )
     exp_val = float(arr.flat[0])
-    grade(exp_val, "lab0-ex3", _CHALLENGE_ID)
+    _grade(exp_val, "ex3")
 
 
 @typechecked
@@ -85,7 +91,7 @@ def grade_lab0_ex4(c_out: list[str], cpp_out: list[str]) -> None:
         "c_out": " ".join(str(x) for x in c_out),
         "cpp_out": " ".join(str(x) for x in cpp_out),
     }
-    grade(answer_dict, "lab0-ex4", _CHALLENGE_ID)
+    _grade(answer_dict, "ex4")
 
 
 @typechecked
@@ -96,4 +102,4 @@ def grade_lab0_ex5(sv: Statevector) -> None:
     Args:
         sv: Statevector object to verify
     """
-    grade(sv, "lab0-ex5", _CHALLENGE_ID)
+    _grade(sv, "ex5")

--- a/qc_grader/challenges/test_challenges/individual.py
+++ b/qc_grader/challenges/test_challenges/individual.py
@@ -8,35 +8,41 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-from typeguard import typechecked
+from typing import Any
+
 from qiskit import QuantumCircuit
+from typeguard import typechecked
 
-from qc_grader.grader.grade import grade
-
+from qc_grader.grader.grade import grade_answer
 
 _CHALLENGE_ID = "test_individual"
+_LAB_ID = "test"
+
+
+def _grade(answer: Any, exercise: str) -> None:
+    grade_answer(answer, lab=_LAB_ID, exercise=exercise, challenge=_CHALLENGE_ID)
 
 
 @typechecked
 def grade_success(answer: str) -> None:
-    grade(answer, "test-pass", _CHALLENGE_ID)
+    _grade(answer, "pass")
 
 
 @typechecked
 def grade_fail(answer: str) -> None:
-    grade(answer, "test-fail", _CHALLENGE_ID)
+    _grade(answer, "fail")
 
 
 @typechecked
 def grade_prime(answer: int) -> None:
-    grade(answer, "test-prime", _CHALLENGE_ID)
+    _grade(answer, "prime")
 
 
 @typechecked
 def grade_vowels(answer: str) -> None:
-    grade(answer, "test-vowels", _CHALLENGE_ID)
+    _grade(answer, "vowels")
 
 
 @typechecked
 def grade_circuit(qc: QuantumCircuit) -> None:
-    grade(qc, "test-circuit", _CHALLENGE_ID)
+    _grade(qc, "circuit")

--- a/qc_grader/challenges/test_challenges/team.py
+++ b/qc_grader/challenges/test_challenges/team.py
@@ -8,13 +8,19 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
+from typing import Any
+
 from qiskit import QuantumCircuit
 from typeguard import typechecked
 
-from qc_grader.grader.grade import grade, submit_team_name
-
+from qc_grader.grader.grade import grade_answer, submit_team_name
 
 _CHALLENGE_ID = "test_team"
+_LAB_ID = "test"
+
+
+def _grade(answer: Any, exercise: str) -> None:
+    grade_answer(answer, lab=_LAB_ID, exercise=exercise, challenge=_CHALLENGE_ID)
 
 
 @typechecked
@@ -24,24 +30,24 @@ def submit_name(name: str) -> None:
 
 @typechecked
 def grade_success(answer: str) -> None:
-    grade(answer, "test-pass", _CHALLENGE_ID)
+    _grade(answer, "pass")
 
 
 @typechecked
 def grade_fail(answer: str) -> None:
-    grade(answer, "test-fail", _CHALLENGE_ID)
+    _grade(answer, "fail")
 
 
 @typechecked
 def grade_prime(answer: int) -> None:
-    grade(answer, "test-prime", _CHALLENGE_ID)
+    _grade(answer, "prime")
 
 
 @typechecked
 def grade_vowels(answer: str) -> None:
-    grade(answer, "test-vowels", _CHALLENGE_ID)
+    _grade(answer, "vowels")
 
 
 @typechecked
 def grade_circuit(qc: QuantumCircuit) -> None:
-    grade(qc, "test-circuit", _CHALLENGE_ID)
+    _grade(qc, "circuit")

--- a/qc_grader/grader/grade.py
+++ b/qc_grader/grader/grade.py
@@ -17,7 +17,7 @@ from .api import send_request
 
 
 def submit_team_name(answer: str, challenge_id: str) -> None:
-    """Send the team name to the validate endpoint's submit-name question and print the result."""
+    """Register the user to the provided team, then print the result."""
 
     print("Submitting your team name. Please wait...")
     try:
@@ -37,13 +37,13 @@ def submit_team_name(answer: str, challenge_id: str) -> None:
     print(f"Failed to submit team name. {cause or ''}")
 
 
-def grade(answer: Any, question: str, challenge: str) -> None:
+def grade_answer(answer: Any, lab: str, exercise: str, challenge: str) -> None:
     """Send the answer to the validate endpoint and print the result."""
 
     print("Grading your answer. Please wait...")
     try:
         answer_response = send_request(
-            f"/challenges/{challenge}/validate/{question}",
+            f"/challenges/{challenge}/validate/{lab}-{exercise}",
             body={"answer": to_json(answer)},
         )
     except Exception as e:


### PR DESCRIPTION
Our application treats labs as a first-class concept, such as the results API allowing you to query by lab. This PR makes more explicit lab vs exercise, rather than having the relationship only expressed in the string format `<lab>-<exercise>`.