### PR TITLE
Use new API for submissions

### DIFF
--- a/qc_grader/grader/api.py
+++ b/qc_grader/grader/api.py
@@ -8,9 +8,9 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-import requests
+from typing import Any
 
-from typing import Mapping
+import requests
 
 from qc_grader import __version__
 from qc_grader.grader.auth import get_access_token
@@ -19,39 +19,24 @@ from qc_grader.grader.env import GRADER_BASE_URL
 
 def send_request(
     endpoint: str,
-    query: dict[str, str] | None = None,
-    body: dict[str, str] | None = None,
+    body: dict[str, Any] | None = None,
     method: str = "POST",
-    header: Mapping[str, str] | None = None,
-) -> dict[str, str]:
+) -> dict[str, Any]:
     headers = {
         "Accept": "application/json",
         "Content-Type": "application/json",
         "X-Client-Version": __version__,
         "Authorization": f"Bearer {get_access_token()}",
-        **(header or {}),
     }
 
     response = requests.request(
-        method,
-        url=f"{GRADER_BASE_URL}{endpoint}",
-        params=query,
-        json=body,
-        headers=headers,
+        method, url=f"{GRADER_BASE_URL}{endpoint}", json=body, headers=headers
     )
 
     if response.status_code == 200:
         return response.json()
 
-    if response.status_code == 403:
-        raise Exception(f"Unable to access service ({response.reason})")
+    if response.status_code == 204:
+        return {}
 
-    try:
-        result = response.json()
-        if "error" in result:
-            result = result["error"]
-        if "message" in result:
-            result = result["message"]
-    except Exception:
-        result = f" Not successful - {response.reason}"
-    raise Exception(result)
+    raise Exception(response.text)

--- a/qc_grader/grader/grade.py
+++ b/qc_grader/grader/grade.py
@@ -8,8 +8,10 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-from typing import Any
+import typeguard
+from typing import Any, TypedDict
 
+from typeguard import check_type
 
 from qc_grader.custom_encoder import to_json
 
@@ -19,69 +21,50 @@ from .api import send_request
 def submit_team_name(answer: str, challenge_id: str) -> None:
     """Register the user to the provided team, then print the result."""
 
-    print("Submitting your team name. Please wait...")
-    try:
-        answer_response = send_request(
-            f"/challenges/{challenge_id}/validate/submit-name",
-            body={"answer": to_json(answer)},
-        )
-    except Exception as e:
-        print(f"Failed: {e}")
-        return
+    print("Submitting your team name. Please wait...\n")
 
-    if answer_response.get("status") == "valid":
-        print("🎉 Team name submitted.")
-        return
 
-    cause = answer_response.get("cause")
-    print(f"Failed to submit team name. {cause or ''}")
+class GradeResponse(TypedDict):
+    passed: bool
+    score: int | float
+    msg: str
 
 
 def grade_answer(answer: Any, lab: str, exercise: str, challenge: str) -> None:
     """Send the answer to the validate endpoint and print the result."""
 
-    print("Grading your answer. Please wait...")
+    print("Grading your answer. Please wait...\n")
     try:
-        answer_response = send_request(
-            f"/challenges/{challenge}/validate/{lab}-{exercise}",
+        response = send_request(
+            f"/submissions/{challenge}/{lab}/{exercise}",
             body={"answer": to_json(answer)},
         )
+        check_type(response, GradeResponse)
+    except typeguard.TypeCheckError as e:
+        print(
+            "Server returned an unexpected response format. Try upgrading the "
+            + "Quantum-Challenge-Grader dependency by following the instructions "
+            + "at https://github.com/Qiskit-community/quantum-challenge-grader. "
+            + f"Error: {e}"
+        )
+        return
     except Exception as e:
         print(f"Failed: {e}")
         return
 
     print(
         determine_grade_response(
-            answer_response.get("status"),
-            score=answer_response.get("score"),
-            cause=answer_response.get("cause"),
+            passed=response["passed"], score=response["score"], msg=response["msg"]
         )
     )
 
 
 def determine_grade_response(
-    status: str | None,
-    score: str | None,
-    cause: str | None,
+    passed: bool,
+    score: int | float,
+    msg: str,
 ) -> str:
-    """Format a human-readable message from a grade response.
-
-    Args:
-        status: 'valid', 'invalid', or 'failed'.
-        score: Numeric score, serialized as a string.
-        cause: Server-provided message explaining the result.
-    """
-    if status == "valid":
-        msg = (
-            cause
-            if cause is not None
-            else "\nCongratulations 🎉! Your answer is correct."
-        )
-        if score is not None:
-            msg += f"\nYour score is {score}."
-        return msg
-
-    if status == "invalid":
-        return f"\nOops 😕! {cause or 'Your answer is incorrect'}\nPlease review your answer and try again."
-
-    return f"Failed: {cause or 'Unexpected error'}\nUnable to grade your answer."
+    """Format a human-readable message from a grade response."""
+    if passed:
+        return msg + f"\nYour score is {score}."
+    return f"\nOops 😕! {msg}\nPlease review your answer and try again."

--- a/qc_grader/grader/grade_test.py
+++ b/qc_grader/grader/grade_test.py
@@ -14,51 +14,18 @@ from qc_grader.grader.grade import determine_grade_response
 
 
 @pytest.mark.parametrize(
-    "status, score, cause, expected",
+    "passed, score, msg, expected",
     [
-        ("valid", None, None, "\nCongratulations 🎉! Your answer is correct."),
+        (True, "100", "Perfect!", "Perfect!\nYour score is 100."),
         (
-            "valid",
-            "95",
-            None,
-            "\nCongratulations 🎉! Your answer is correct.\nYour score is 95.",
-        ),
-        ("valid", None, "Well done!", "Well done!"),
-        ("valid", "100", "Perfect!", "Perfect!\nYour score is 100."),
-        (
-            "invalid",
-            None,
-            None,
-            "\nOops 😕! Your answer is incorrect\nPlease review your answer and try again.",
-        ),
-        (
-            "invalid",
-            None,
-            "Off by one",
-            "\nOops 😕! Off by one\nPlease review your answer and try again.",
-        ),
-        (
-            "invalid",
+            False,
             "50",
             "Wrong",
             "\nOops 😕! Wrong\nPlease review your answer and try again.",
         ),
-        (
-            "failed",
-            None,
-            "Server error",
-            "Failed: Server error\nUnable to grade your answer.",
-        ),
-        (
-            "failed",
-            None,
-            None,
-            "Failed: Unexpected error\nUnable to grade your answer.",
-        ),
-        (None, None, None, "Failed: Unexpected error\nUnable to grade your answer."),
     ],
 )
 def test_determine_grade_response(
-    status: str | None, score: str | None, cause: str | None, expected: str
+    passed: bool, score: int | float, msg: str, expected: str
 ) -> None:
-    assert determine_grade_response(status, score, cause) == expected
+    assert determine_grade_response(passed, score, msg) == expected


### PR DESCRIPTION
The server recently made a breaking change:

* New URL for submitting an answer
* Removed the `status` type in favor of `passed: bool`
* Now returns 400s and 500s on errors, rather than a 200. The errors are also a plain string, rather than JSON.
* `score` and `msg` are always set.

This PR switches to the new API format. In the process, it improves the code clarity:

* Removes special handling of 400s and 500s
* Uses `typeguard` to validate that the server returned the types we expected. This is nice to make type checkers happy and to avoid future confusing scenarios where the server makes a breaking change and the user's client is still an old version.

I still want to improve the way we display the result string to the user, but I'm saving that for a follow-up.