### PR TITLE
Improve UX of payload size limit

### DIFF
--- a/qc_grader/grader/api.py
+++ b/qc_grader/grader/api.py
@@ -39,4 +39,8 @@ def send_request(
     if response.status_code == 204:
         return {}
 
-    raise Exception(response.text)
+    error_text = response.text.strip()
+    if not error_text or error_text.startswith("<"):  # HTML error page, e.g. nginx 413
+        raise Exception(f"{response.status_code} {response.reason}")
+
+    raise Exception(error_text)


### PR DESCRIPTION
Closes https://github.com/qiskit-community/Quantum-Challenge-Grader/issues/290.

If you send too big of a request, you now get this error:

```
>>> grade_success("x" * (50 * 1024 * 1024))
Grading your answer. Please wait...

Failed: 413 Payload Too Large
```

We don't add a proactive payload size check to the client because:

1. It's not worth the code complexity
2. It's too brittle that the client's limit might conflict with future changes to the server's limit

A client check would solely be for better UX. For proper security, the limit must live on the server. The UX is already acceptable enough.