### PR TITLE
Account auth reads account saved as grader

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ Pre-requisites:
 To install the grader locally:
 
 1. In the Python environment, install the grading client: `pip install git+https://github.com/qiskit-community/Quantum-Challenge-Grader.git`
-1. Configure the `IBMCLOUD_API_KEY` environment variables
+1. Configure the `QC_API_KEY` environment variables
 
     From a terminal (before launching your JupyterLab environment), enter
 
     ```
-    export IBMCLOUD_API_KEY=your_ibmcloud_api_key
+    export QC_API_KEY=your_ibmcloud_api_key
     ```
 
     where `your_ibmcloud_api_key` is your IBM Cloud API Key found in your **[Account page](https://cloud.ibm.com/iam/apikeys)**.
@@ -27,7 +27,7 @@ To install the grader locally:
     Alternatively, if you prefer you can instead run the following at the top cell of a notebook cell (whenever you start/restart the kernel)
 
     ```
-    %set_env IBMCLOUD_API_KEY=your_ibmcloud_api_key
+    %set_env QC_API_KEY=your_ibmcloud_api_key
     ```
 
 
@@ -36,7 +36,7 @@ To install the grader locally:
     > 
     > ```python
     > import os
-    > print(os.getenv('IBMCLOUD_API_KEY'))
+    > print(os.getenv('QC_API_KEY'))
     > ```
     > 
     > **Note2**: If you already installed [qiskit-ibm-runtime](https://github.com/Qiskit/qiskit-ibm-runtime) and saved your token by using `QiskitRuntimeService` by following [this instruction](https://quantum.cloud.ibm.com/docs/en/guides/cloud-setup#set-up-to-use-ibm-cloud) once, you don't need to set-up the env variable. You can save your token by using `QiskitRuntimeService` like below:

--- a/qc_grader/grader/auth.py
+++ b/qc_grader/grader/auth.py
@@ -31,8 +31,7 @@ def read_api_key() -> str | None:
 
     1. Read the `QC_API_KEY` env var.
     2. If it's staging or local development, read `saved_accounts().get("grader-staging")`.
-    3. Read the legacy `IBMCLOUD_API_KEY` env var, with fallback to `saved_accounts().get("qdc-2025")`.
-       We start with this to avoid breaking Road To Practioner users still using qdc-2025.
+    3. Read `saved_accounts().get("grader")`
     4. Read the default account with QiskitRuntimeService.
 
     Once qdc-2025 is no longer used, we can remove the legacy approach.
@@ -45,9 +44,7 @@ def read_api_key() -> str | None:
         .get("token")
     ):
         return key
-    if key := os.environ.get("IBMCLOUD_API_KEY"):
-        return key
-    if key := QiskitRuntimeService.saved_accounts().get("qdc-2025", {}).get("token"):
+    if key := QiskitRuntimeService.saved_accounts().get("grader", {}).get("token"):
         return key
     if key := (QiskitRuntimeService().active_account() or {}).get("token"):
         return key


### PR DESCRIPTION
Request from `@0sophy1`.

This also removes the legacy approach for QDC 2025 because that challenge is over.