### PR TITLE
Publish to PyPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,147 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'qc_grader/__init__.py'
+  workflow_dispatch:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.get-version.outputs.version }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get version from qc_grader/__init__.py
+        id: get-version
+        run: |
+          VERSION=$(python -c "import re; print(re.search(r'__version__\s*=\s*\"([^\"]+)\"', open('qc_grader/__init__.py').read()).group(1))")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Version to release: $VERSION"
+
+      - name: Validate version format (YEAR.MONTH.DAY, no leading zeros)
+        run: |
+          VERSION="${{ steps.get-version.outputs.version }}"
+          if ! [[ "$VERSION" =~ ^[0-9]{4}\.(1[0-2]|[1-9])\.(3[01]|[12][0-9]|[1-9])(\.[0-9]+)?$ ]]; then
+            echo "Error: Invalid version format: $VERSION"
+            echo "Expected a date-based version YEAR.MONTH.DAY with no leading zeros, e.g. 2026.6.18"
+            exit 1
+          fi
+
+      - name: Check if tag exists
+        run: |
+          VERSION="${{ steps.get-version.outputs.version }}"
+          if git ls-remote --tags origin "v$VERSION" | grep -q .; then
+            echo "Error: Tag v$VERSION already exists"
+            exit 1
+          fi
+
+  test:
+    needs: validate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.10"
+      - uses: extractions/setup-just@v3
+      - name: install
+        run: uv sync
+      - run: just lint
+      - run: just test
+
+  build:
+    needs: [validate, test]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+
+      - name: Build distribution
+        run: uv build
+
+      - name: Store the distribution packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+  publish-to-pypi:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/qc_grader/
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Publish distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+  create-release:
+    needs: [validate, publish-to-pypi]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create and push tag
+        run: |
+          VERSION="${{ needs.validate.outputs.version }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "v$VERSION" -m "Release version $VERSION"
+          git push origin "v$VERSION"
+
+      - name: Write release notes
+        env:
+          VERSION: ${{ needs.validate.outputs.version }}
+          REPO: ${{ github.repository }}
+        run: |
+          # The previous release tag, if any. HEAD is already tagged v$VERSION,
+          # so look at HEAD^ to find the prior release.
+          PREV=$(git describe --tags --abbrev=0 --match 'v*' "v$VERSION^" 2>/dev/null || true)
+          if [ -n "$PREV" ]; then
+            URL="https://github.com/$REPO/compare/$PREV...v$VERSION"
+          else
+            URL="https://github.com/$REPO/commits/v$VERSION"
+          fi
+          {
+            echo "**What changed:** see the commits included in this release:"
+            echo ""
+            echo "$URL"
+          } > release-notes.md
+          cat release-notes.md
+
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          gh release create "v$VERSION" \
+            --title "v$VERSION" \
+            --notes-file release-notes.md \
+            dist/*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,8 +10,6 @@ Users are primarily students and are sometimes beginners to either programming o
 
 ## Workflows
 
-Refer to the file `CONTRIBUTING.md` for instructions on how to run the project and extend it:
-
 * Format: `just fmt`
 * Linter and type checker: `just lint`
 * Test: `just test`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,8 @@ Users are primarily students and are sometimes beginners to either programming o
 
 Refer to the file `CONTRIBUTING.md` for instructions on how to run the project and extend it:
 
-* Run formatter
-* Run Ruff linter and ty type checker
-* Run Pytest tests
-* Add new labs and exercises
+* Format: `just fmt`
+* Linter and type checker: `just lint`
+* Test: `just test`
+* Add new labs and exercises: refer to `CONTRIBUTING.md`
+* Releases: refer to `CONTRIBUTING.md`. All user-facing changes should have a new release.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,16 +40,10 @@ just test
 
 ([Original documentation](https://docs.astral.sh/uv/concepts/projects/dependencies/))
 
-Add a core dependency:
+Add a dependency:
 
 ```
 uv add <dependency>
-```
-
-Add an extra:
-
-```
-uv add <dependnecy> --optional qiskit
 ```
 
 Add a dev dependency:
@@ -57,6 +51,37 @@ Add a dev dependency:
 ```
 uv add <dependency> --dev
 ```
+
+## Release a new version
+
+You should release a new version any time you make user-facing changes.
+
+Releasing is automated. To cut a release, update `__version__` in
+[`qc_grader/__init__.py`](qc_grader/__init__.py) to **today's date** and merge to `main`.
+A GitHub Actions workflow then builds the package, publishes it to PyPI, and creates a
+GitHub Release whose notes link to the commits included in that release.
+
+### Version format
+
+Versions are date-based, written as **`YEAR.MONTH.DAY`** with **no leading zeros**:
+
+* The year comes first, then the month, then the day (`YEAR.MONTH.DAY`).
+* Do not pad with zeros: use `6`, not `06`.
+
+For example, a release made on **18 June 2026** is version `2026.6.18`.
+
+| Date           | Version     |
+| -------------- | ----------- |
+| 18 June 2026   | `2026.6.18` |
+| 1 December 2026 | `2026.12.1` |
+| 5 January 2027 | `2027.1.5`  |
+
+If you need to release more than once on the same day, add a counter at the end, starting
+at `.1`: the second release on 18 June 2026 is `2026.6.18.1`, the third is `2026.6.18.2`,
+and so on.
+
+Versions only ever move forward — we always release from the latest `main` and never
+maintain older versions in parallel.
 
 ## Run the client
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Pre-requisites:
 
 To install the grader locally:
 
-1. In the Python environment, install the grading client: `pip install git+https://github.com/qiskit-community/Quantum-Challenge-Grader.git`
+1. In the Python environment, install the grading client: `pip install qc-grader`
 1. Configure the `QC_API_KEY` environment variables
 
     From a terminal (before launching your JupyterLab environment), enter

--- a/qc_grader/__init__.py
+++ b/qc_grader/__init__.py
@@ -12,4 +12,4 @@ import warnings
 
 warnings.filterwarnings("ignore")
 
-__version__ = "0.23.0"
+__version__ = "2026.6.18"


### PR DESCRIPTION
Claude took most the code from https://github.com/ibm/qauvern. We use PyPI's OIDC mechanism, which is a very ergonomic and secure integration with GitHub Actions. I configured in PyPI a "trusted publisher" at https://pypi.org/manage/account/publishing/, and set up an Environment in GitHub called "pypi".

## No changelog

We use Git as our changelog instead. The motivation is to make it easier for challenge authors to do a release. We also don't really expect users to be reading a changelog closely.

## Calver rather than semver

We use date-based versions rather than semantic versioning (semver). We don't expect to support multiple versions concurrently, and we want users to always use the latest version. So semantic versioning isn't very useful. Calver is easier to use.