### PR TITLE
Add client-side payload check

### DIFF
--- a/qc_grader/grader/grade.py
+++ b/qc_grader/grader/grade.py
@@ -72,11 +72,11 @@ def grade_answer(answer: Any, lab: str, exercise: str, challenge: str) -> None:
     print("Grading your answer. Please wait...\n")
     try:
         answer_json_str = to_json(answer)
-        answer_bytes = answer_json_str.encode("utf-8")
-        if len(answer_bytes) > _MAX_ANSWER_BYTES:
+        # len() == byte count because json.dumps uses ensure_ascii=True (default), producing pure ASCII.
+        if len(answer_json_str) > _MAX_ANSWER_BYTES:
             print(
                 f"Your answer is too large to submit "
-                f"({len(answer_bytes) / 1024 / 1024:.1f} MB). "
+                f"({len(answer_json_str) / 1024 / 1024:.1f} MB). "
                 "Please simplify your answer and try again."
             )
             return

--- a/qc_grader/grader/grade.py
+++ b/qc_grader/grader/grade.py
@@ -62,14 +62,26 @@ class GradeResponse(TypedDict):
     msg: str
 
 
+_MAX_ANSWER_BYTES = 50 * 1024 * 1024  # 50 MB
+
+
 def grade_answer(answer: Any, lab: str, exercise: str, challenge: str) -> None:
     """Send the answer to the validate endpoint and print the result."""
 
     print("Grading your answer. Please wait...\n")
     try:
+        answer_json_str = to_json(answer)
+        answer_bytes = answer_json_str.encode("utf-8")
+        if len(answer_bytes) > _MAX_ANSWER_BYTES:
+            print(
+                f"Your answer is too large to submit "
+                f"({len(answer_bytes) / 1024 / 1024:.1f} MB). "
+                "Please simplify your answer and try again."
+            )
+            return
         response = send_request(
             f"/submissions/{challenge}/{lab}/{exercise}",
-            body={"answer": to_json(answer)},
+            body={"answer": answer_json_str},
         )
         check_type(response, GradeResponse)
     except typeguard.TypeCheckError as e:

--- a/qc_grader/grader/grade.py
+++ b/qc_grader/grader/grade.py
@@ -63,7 +63,7 @@ class GradeResponse(TypedDict):
 
 
 # Payload limits are also set in the server and may need to be adjusted.
-_MAX_ANSWER_BYTES = 50 * 1024 * 1024  # 50 MB
+_MAX_ANSWER_BYTES = 20 * 1024 * 1024  # 20 MB
 
 
 def grade_answer(answer: Any, lab: str, exercise: str, challenge: str) -> None:
@@ -74,9 +74,10 @@ def grade_answer(answer: Any, lab: str, exercise: str, challenge: str) -> None:
         answer_json_str = to_json(answer)
         # len() == byte count because json.dumps uses ensure_ascii=True (default), producing pure ASCII.
         if len(answer_json_str) > _MAX_ANSWER_BYTES:
+            limit_mb = _MAX_ANSWER_BYTES / 1024 / 1024
             print(
                 f"Your answer is too large to submit "
-                f"({len(answer_json_str) / 1024 / 1024:.1f} MB). "
+                f"({len(answer_json_str) / 1024 / 1024:.1f} MB, limit is {limit_mb:.0f} MB). "
                 "Please simplify your answer and try again."
             )
             return

--- a/qc_grader/grader/grade.py
+++ b/qc_grader/grader/grade.py
@@ -62,6 +62,7 @@ class GradeResponse(TypedDict):
     msg: str
 
 
+# Payload limits are also set in the server and may need to be adjusted.
 _MAX_ANSWER_BYTES = 50 * 1024 * 1024  # 50 MB
 
 

--- a/qc_grader/grader/grade_test.py
+++ b/qc_grader/grader/grade_test.py
@@ -9,11 +9,13 @@
 # that they have been altered from the originals.
 
 import pytest
+from unittest.mock import patch
 
 from qc_grader.grader.grade import (
     ProgressResponse,
     determine_grade_response,
     determine_progress_response,
+    grade_answer,
 )
 
 
@@ -183,3 +185,11 @@ def test_determine_progress_response(
 def test_determine_progress_response_unknown_lab() -> None:
     with pytest.raises(ValueError, match='No lab named "lab_missing" found.'):
         determine_progress_response(_MULTI_LAB_RESPONSE, lab_name="lab_missing")
+
+
+def test_grade_answer_too_large(capsys: pytest.CaptureFixture) -> None:
+    with patch("qc_grader.grader.grade._MAX_ANSWER_BYTES", 10):
+        grade_answer("this answer is definitely over 10 bytes", "lab1", "ex1", "ch1")
+    out = capsys.readouterr().out
+    assert "too large to submit" in out
+    assert "MB" in out


### PR DESCRIPTION
Closes https://github.com/qiskit-community/Quantum-Challenge-Grader/issues/290. This proactive check saves the user time and reduces network load.